### PR TITLE
Feautre/#10,11-add-GroupSelectBtn, TitleDate

### DIFF
--- a/src/components/HomeHeaderContainer/GroupSelectBtn/GroupSelectBtn.stories.ts
+++ b/src/components/HomeHeaderContainer/GroupSelectBtn/GroupSelectBtn.stories.ts
@@ -1,0 +1,17 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import GroupSelectBtn from './GroupSelectBtn';
+
+const meta = {
+  title: 'GroupSelectBtn',
+  component: GroupSelectBtn,
+  tags: ['autodocs'],
+} satisfies Meta<typeof GroupSelectBtn>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    groupName: '우리집',
+  },
+};

--- a/src/components/HomeHeaderContainer/GroupSelectBtn/GroupSelectBtn.tsx
+++ b/src/components/HomeHeaderContainer/GroupSelectBtn/GroupSelectBtn.tsx
@@ -1,5 +1,17 @@
-const GroupSelectBtn = () => {
-  return <div>GroupSelectBtn</div>;
+import React from 'react';
+
+interface GroupSelectBtnProps {
+  /** 현재 속해있는 그룹명 */
+  groupName: string;
+}
+
+const GroupSelectBtn: React.FC<GroupSelectBtnProps> = ({ groupName }: GroupSelectBtnProps) => {
+  return (
+    <button className='bg-gray03 text-12 text-white03 flex items-center rounded-full px-2 py-1'>
+      <div className='bg-gray01 h-4 w-4 rounded-full'></div>
+      <div className='pl-2'>{groupName}</div>
+    </button>
+  );
 };
 
 export default GroupSelectBtn;

--- a/src/components/HomeHeaderContainer/HomeHeaderContainer.stories.ts
+++ b/src/components/HomeHeaderContainer/HomeHeaderContainer.stories.ts
@@ -1,0 +1,12 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import HomeHeaderContainer from './HomeHeaderContainer';
+
+const meta = {
+  title: 'HomeHeaderContainer',
+  component: HomeHeaderContainer,
+} satisfies Meta<typeof HomeHeaderContainer>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/src/components/HomeHeaderContainer/HomeHeaderContainer.tsx
+++ b/src/components/HomeHeaderContainer/HomeHeaderContainer.tsx
@@ -1,5 +1,13 @@
+import GroupSelectBtn from './GroupSelectBtn/GroupSelectBtn';
+import TitleDate from './TitleDate/TitleDate';
+
 const HomeHeaderContainer = () => {
-  return <div>HomeHeaderContainer</div>;
+  return (
+    <div className='bg-white02 flex items-center justify-between p-5'>
+      <TitleDate dateText='2024년 11월 둘째 주' />
+      <GroupSelectBtn groupName='우리집' />
+    </div>
+  );
 };
 
 export default HomeHeaderContainer;

--- a/src/components/HomeHeaderContainer/TitleDate/TitleDate.stories.ts
+++ b/src/components/HomeHeaderContainer/TitleDate/TitleDate.stories.ts
@@ -1,0 +1,17 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import TitleDate from './TitleDate';
+
+const meta = {
+  title: 'TitleDate',
+  component: TitleDate,
+  tags: ['autodocs'],
+} satisfies Meta<typeof TitleDate>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    dateText: '2024년 11월 둘째 주',
+  },
+};

--- a/src/components/HomeHeaderContainer/TitleDate/TitleDate.tsx
+++ b/src/components/HomeHeaderContainer/TitleDate/TitleDate.tsx
@@ -1,5 +1,12 @@
-const TitleDate = () => {
-  return <div>TitleDate</div>;
+import React from 'react';
+
+interface TitleDateProps {
+  /** 타이틀 날짜의 내용 */
+  dateText: string;
+}
+
+const TitleDate: React.FC<TitleDateProps> = ({ dateText }: TitleDateProps) => {
+  return <div className='text-gray02'>{dateText}</div>;
 };
 
 export default TitleDate;


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약

> ex) 메인페이지 - 라우트 연결

클릭(터치)하면 그룹을 옮길 수 있는 시트가 뜨는 버튼인데, 퍼블리싱했습니다.
홈 헤더에 몇째 주인지 뜨는 텍스트를 퍼블리싱했습니다.

이 두개가 들어있는 컨테이너를 퍼블리싱했습니다.

## 📌 이슈 넘버

> ex) #이슈번호, #이슈번호

#10 #11 #12 

## 📝 작업 내용

퍼블리싱

## 📸 스크린샷(선택)

<img width="100" alt="화면 캡처 2024-11-21 121826" src="https://github.com/user-attachments/assets/3e1633e2-67b3-448d-b977-2158d21a4855">

<img width="160" alt="화면 캡처 2024-11-21 122505" src="https://github.com/user-attachments/assets/d8becc8b-df3f-45a5-89f8-f71aad3dce16">

<img width="368" alt="화면 캡처 2024-11-21 123320" src="https://github.com/user-attachments/assets/b7bb79d6-cc8c-4f22-93c7-3f2f6624b06a">


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
