### PR TITLE
Feature/#6-바텀 내비게이션 버튼 컴포넌트 추가

### DIFF
--- a/src/components/common/BottomNavContainer/AddHouseWorkBtn/AddHouseWorkBtn.stories.ts
+++ b/src/components/common/BottomNavContainer/AddHouseWorkBtn/AddHouseWorkBtn.stories.ts
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react';
 import AddHouseWorkBtn from './AddHouseWorkBtn';
 
 const meta = {
-  title: 'Components/AddHouseWorkBtn',
+  title: 'Components/AddHouseWorkBtn/AddHouseWorkBtn',
   component: AddHouseWorkBtn,
   parameters: {
     layout: 'centered',

--- a/src/components/common/BottomNavContainer/BottomNavBtn/BottomNavBtn.stories.ts
+++ b/src/components/common/BottomNavContainer/BottomNavBtn/BottomNavBtn.stories.ts
@@ -1,0 +1,52 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import BottomNavBtn from './BottomNavBtn';
+
+const meta = {
+  title: 'Components/BottomNavBtn/BottomNavBtn',
+  component: BottomNavBtn,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    icon: {
+      control: 'text',
+      description: '버튼에 표시될 아이콘',
+    },
+    name: {
+      control: 'text',
+      description: '버튼 아래에 표시될 텍스트',
+    },
+  },
+} satisfies Meta<typeof BottomNavBtn>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    icon: '',
+    name: '홈',
+  },
+};
+
+export const Statistics: Story = {
+  args: {
+    icon: '',
+    name: '통계',
+  },
+};
+
+export const Settings: Story = {
+  args: {
+    icon: '',
+    name: '설정',
+  },
+};
+
+export const My: Story = {
+  args: {
+    icon: '',
+    name: '마이',
+  },
+};

--- a/src/components/common/BottomNavContainer/BottomNavBtn/BottomNavBtn.tsx
+++ b/src/components/common/BottomNavContainer/BottomNavBtn/BottomNavBtn.tsx
@@ -1,5 +1,23 @@
-const BottomNavBtn = () => {
-  return <div>BottomNavBtn</div>;
+import React from 'react';
+
+interface BottomNavBtnProps {
+  icon: React.ReactNode;
+  name: string;
+}
+
+const BottomNavBtn: React.FC<BottomNavBtnProps> = ({
+  /** 아이콘 */
+  icon,
+  /** menu name */
+  name,
+}) => {
+  return (
+    <button className='flex flex-col items-center gap-1'>
+      {/* <div>{icon}</div> */}
+      <div className='bg-gray01 h-6 w-6 rounded-full border-2'></div>
+      <p className='text-12'>{name}</p>
+    </button>
+  );
 };
 
 export default BottomNavBtn;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -22,6 +22,7 @@ export default {
       white03: '#FFFFFF',
     },
     fontSize: {
+      12: '0.75rem',
       14: '0.875rem',
       16: '1rem',
       24: '1.5rem',


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약

> 공통-바텀 네비게이션 버튼

## 📌 이슈 넘버

> #6

## 📝 작업 내용
- bottomNavBtn 컴포넌트 추가
- tailwind.config 폰트 12px 추가
- AddHouseWorkBtn.stories파일 경로 수정

## 📸 스크린샷(선택)
![image](https://github.com/user-attachments/assets/d57bec93-0fbf-485c-b008-dbcb80185a1f)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
