### PR TITLE
Feature/#7-홈 날짜(Weekly) 컨테이너 추가

### DIFF
--- a/src/components/WeeklyDateContainer/DateItem/DateItem.stories.tsx
+++ b/src/components/WeeklyDateContainer/DateItem/DateItem.stories.tsx
@@ -20,6 +20,6 @@ export const Default: Story = {
     day: '월',
     pendingCnt: 1,
     isActive: true,
-    onClick: action('DateItem clicked'),
+    handleClick: action('DateItem clicked'),
   },
 };

--- a/src/components/WeeklyDateContainer/DateItem/DateItem.stories.tsx
+++ b/src/components/WeeklyDateContainer/DateItem/DateItem.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
+import { action } from '@storybook/addon-actions';
 import DateItem from './DateItem';
 
 const meta = {
@@ -19,5 +20,6 @@ export const Default: Story = {
     day: '월',
     pendingCnt: 1,
     isActive: true,
+    onClick: action('DateItem clicked'),
   },
 };

--- a/src/components/WeeklyDateContainer/DateItem/DateItem.tsx
+++ b/src/components/WeeklyDateContainer/DateItem/DateItem.tsx
@@ -7,12 +7,15 @@ interface DateItemProps {
   pendingCnt: number;
   /** 활성화 상태 */
   isActive: boolean;
+  /** 클릭 이벤트 */
+  onClick: () => void;
 }
 
-const DateItem = ({ date, day, pendingCnt, isActive }: DateItemProps) => {
+const DateItem = ({ date, day, pendingCnt, isActive, onClick }: DateItemProps) => {
   return (
     // TODO rounded, font-weight 공통변수로 수정할 예정
     <div
+      onClick={onClick}
       className={`flex h-20 w-10 flex-col items-center justify-center gap-0.5 rounded-[30px] px-2 py-1 ${isActive ? 'bg-black02' : 'bg-white03'} `}
     >
       <span className={`text-14 ${isActive ? 'text-gray03' : 'text-gray02'}`}>{date}</span>

--- a/src/components/WeeklyDateContainer/DateItem/DateItem.tsx
+++ b/src/components/WeeklyDateContainer/DateItem/DateItem.tsx
@@ -8,14 +8,14 @@ interface DateItemProps {
   /** 활성화 상태 */
   isActive: boolean;
   /** 클릭 이벤트 */
-  onClick: () => void;
+  handleClick: () => void;
 }
 
-const DateItem = ({ date, day, pendingCnt, isActive, onClick }: DateItemProps) => {
+const DateItem = ({ date, day, pendingCnt, isActive, handleClick }: DateItemProps) => {
   return (
     // TODO rounded, font-weight 공통변수로 수정할 예정
     <div
-      onClick={onClick}
+      onClick={handleClick}
       className={`flex h-20 w-10 flex-col items-center justify-center gap-0.5 rounded-[30px] px-2 py-1 ${isActive ? 'bg-black02' : 'bg-white03'} `}
     >
       <span className={`text-14 ${isActive ? 'text-gray03' : 'text-gray02'}`}>{date}</span>

--- a/src/components/WeeklyDateContainer/WeeklyDateContainer.stories.ts
+++ b/src/components/WeeklyDateContainer/WeeklyDateContainer.stories.ts
@@ -1,0 +1,13 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import WeeklyDateContainer from './WeeklyDateContainer';
+
+const meta = {
+  title: 'components/WeeklyDateContainer',
+  component: WeeklyDateContainer,
+  tags: ['autodocs'],
+} satisfies Meta<typeof WeeklyDateContainer>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/src/components/WeeklyDateContainer/WeeklyDateContainer.tsx
+++ b/src/components/WeeklyDateContainer/WeeklyDateContainer.tsx
@@ -1,0 +1,36 @@
+import { useState } from 'react';
+import DateItem from './DateItem/DateItem';
+
+const WeeklyDateContainer = () => {
+  const dummyItems = [
+    { date: 18, day: '월', pendingCnt: 2 },
+    { date: 19, day: '화', pendingCnt: 0 },
+    { date: 20, day: '수', pendingCnt: 1 },
+    { date: 21, day: '목', pendingCnt: 4 },
+    { date: 22, day: '금', pendingCnt: 3 },
+    { date: 23, day: '토', pendingCnt: 0 },
+    { date: 24, day: '일', pendingCnt: 4 },
+  ];
+
+  const [activeDate, setActiveDate] = useState<number>();
+  const handleActiveDate = (idx: number) => {
+    setActiveDate(idx);
+  };
+
+  return (
+    <div className='flex items-center gap-3 py-2'>
+      {dummyItems.map((item, idx) => (
+        <DateItem
+          key={idx}
+          date={item.date}
+          day={item.day}
+          pendingCnt={item.pendingCnt}
+          isActive={activeDate === idx}
+          onClick={() => handleActiveDate(idx)}
+        />
+      ))}
+    </div>
+  );
+};
+
+export default WeeklyDateContainer;


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약

> 홈 - 날짜(Weekly) 컨테이너 추가

## 📌 이슈 넘버

> #7 

## 📝 작업 내용
- 날짜(Weekly) 컨테이너 추가
- 날짜 컴포넌트 클릭이벤트 props 추가

## 📸 스크린샷(선택)
![image](https://github.com/user-attachments/assets/aedef8e2-74f2-4b99-a228-98b8a2a3ebb8)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
