### PR TITLE
Feature/#17-add-BottomSheetContainer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "react": "^18.3.1",
         "react-day-picker": "^9.3.2",
         "react-dom": "^18.3.1",
+        "react-modal-sheet": "^3.3.0",
         "react-router-dom": "^6.28.0",
         "sockjs-client": "^1.6.1",
         "vite-plugin-svgr": "^4.3.0",
@@ -1594,6 +1595,37 @@
         "url": "https://opencollective.com/popperjs"
       }
     },
+    "node_modules/@react-aria/ssr": {
+      "version": "3.9.6",
+      "resolved": "https://registry.npmjs.org/@react-aria/ssr/-/ssr-3.9.6.tgz",
+      "integrity": "sha512-iLo82l82ilMiVGy342SELjshuWottlb5+VefO3jOQqQRNYnJBFpUSadswDPbRimSgJUZuFwIEYs6AabkP038fA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
+      },
+      "engines": {
+        "node": ">= 12"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@react-aria/utils": {
+      "version": "3.25.3",
+      "resolved": "https://registry.npmjs.org/@react-aria/utils/-/utils-3.25.3.tgz",
+      "integrity": "sha512-PR5H/2vaD8fSq0H/UB9inNbc8KDcVmW6fYAfSWkkn+OAdhTTMVKqXXrZuZBWyFfSD5Ze7VN6acr4hrOQm2bmrA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/ssr": "^3.9.6",
+        "@react-stately/utils": "^3.10.4",
+        "@react-types/shared": "^3.25.0",
+        "@swc/helpers": "^0.5.0",
+        "clsx": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/@react-spring/animated": {
       "version": "9.7.5",
       "resolved": "https://registry.npmjs.org/@react-spring/animated/-/animated-9.7.5.tgz",
@@ -1658,6 +1690,27 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/@react-stately/utils": {
+      "version": "3.10.4",
+      "resolved": "https://registry.npmjs.org/@react-stately/utils/-/utils-3.10.4.tgz",
+      "integrity": "sha512-gBEQEIMRh5f60KCm7QKQ2WfvhB2gLUr9b72sqUdIZ2EG+xuPgaIlCBeSicvjmjBvYZwOjoOEnmIkcx2GHp/HWw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@react-types/shared": {
+      "version": "3.25.0",
+      "resolved": "https://registry.npmjs.org/@react-types/shared/-/shared-3.25.0.tgz",
+      "integrity": "sha512-OZSyhzU6vTdW3eV/mz5i6hQwQUhkRs7xwY2d1aqPvTdMe0+2cY7Fwp45PAiwYLEj73i9ro2FxF9qC4DvHGSCgQ==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/@remix-run/router": {
@@ -2670,6 +2723,15 @@
       },
       "peerDependencies": {
         "@svgr/core": "*"
+      }
+    },
+    "node_modules/@swc/helpers": {
+      "version": "0.5.15",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
+      "integrity": "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.8.0"
       }
     },
     "node_modules/@tanstack/query-core": {
@@ -6362,6 +6424,22 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true
+    },
+    "node_modules/react-modal-sheet": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/react-modal-sheet/-/react-modal-sheet-3.3.0.tgz",
+      "integrity": "sha512-r9NtMOMH9StPViRVDyBJjAd465GUfbLndyB4PBH79De9XBtD0PwVgf9VIg6lK4dTZWnGlxaV2iBgm7uqbTx5ig==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-aria/utils": "3.25.3"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "framer-motion": ">=10",
+        "react": ">=16"
+      }
     },
     "node_modules/react-refresh": {
       "version": "0.14.2",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "react": "^18.3.1",
     "react-day-picker": "^9.3.2",
     "react-dom": "^18.3.1",
+    "react-modal-sheet": "^3.3.0",
     "react-router-dom": "^6.28.0",
     "sockjs-client": "^1.6.1",
     "vite-plugin-svgr": "^4.3.0",

--- a/src/components/common/BottomSheetContainer/BottomSheetContainer.stories.ts
+++ b/src/components/common/BottomSheetContainer/BottomSheetContainer.stories.ts
@@ -1,0 +1,12 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import BottomSheetContainer from './BottomSheetContainer';
+
+const meta = {
+  title: 'components/BottomSheetContainer',
+  component: BottomSheetContainer,
+} satisfies Meta<typeof BottomSheetContainer>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/src/components/common/BottomSheetContainer/BottomSheetContainer.tsx
+++ b/src/components/common/BottomSheetContainer/BottomSheetContainer.tsx
@@ -1,0 +1,35 @@
+import { Sheet } from 'react-modal-sheet';
+import { useState } from 'react';
+import BottomSheetCloseBtn from './BottomSheetCloseBtn/BottomSheetCloseBtn';
+import BottomSheetTitle from './BottomSheetTitle/BottomSheetTitle';
+
+const BottomSheetContainer = () => {
+  const [isOpen, setOpen] = useState(false);
+  return (
+    <>
+      <button onClick={() => setOpen(true)}>Open sheet</button>
+
+      <Sheet
+        isOpen={isOpen}
+        onClose={() => setOpen(false)}
+        detent='content-height'
+        disableDrag={true}
+      >
+        <div className='relative mx-auto h-full w-full max-w'>
+          <Sheet.Container>
+            <BottomSheetCloseBtn handleClick={() => setOpen(false)} />
+            <Sheet.Header>
+              <BottomSheetTitle title='모임 변경' />
+            </Sheet.Header>
+            <Sheet.Content>
+              <div className='px-5 py-8'>Some content</div>
+            </Sheet.Content>
+          </Sheet.Container>
+        </div>
+        <Sheet.Backdrop />
+      </Sheet>
+    </>
+  );
+};
+
+export default BottomSheetContainer;

--- a/src/index.css
+++ b/src/index.css
@@ -7,3 +7,22 @@
     @apply font-Pretendard;
   }
 }
+
+.react-modal-sheet-container {
+  /* margin: 0 auto !important;
+  max-width: 430px !important;
+  width: 100% !important; */
+  border-top-left-radius: 1rem !important;
+  border-top-right-radius: 1rem !important;
+  box-shadow: none !important;
+}
+
+.react-modal-sheet-header {
+  /* custom styles */
+  border-top-left-radius: 1rem;
+  border-top-right-radius: 1rem;
+}
+
+.react-modal-sheet-drag-indicator {
+  display: none;
+}


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약

> ex) 메인페이지 - 라우트 연결

https://github.com/Temzasse/react-modal-sheet
바텀시트 라이브러리를 설치해서 바텀시트컨테이너를 만들었습니다.
npm install 하셔야합니다.

## 📌 이슈 넘버

> ex) #이슈번호, #이슈번호

#17 

## 📝 작업 내용

퍼블리싱

## 📸 스크린샷(선택)

<img width="323" alt="화면 캡처 2024-11-21 171834" src="https://github.com/user-attachments/assets/66ecddd8-965b-4be8-9b90-43aabedc7982">


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

index.css에 apply 하려고했는데
기존 라이브러리가 인라인 스타일로 되어있어서 어쩔수없이 이렇게 진행했습니다.
