### PR TITLE
Feature/#56-집안일 카테고리 태그 컴포넌트 추가

### DIFF
--- a/src/components/common/HouseworkCatetoryTag/HouseworkCategoryTag.stories.ts
+++ b/src/components/common/HouseworkCatetoryTag/HouseworkCategoryTag.stories.ts
@@ -4,7 +4,7 @@ import HouseworkCategoryTag, {
 } from '@/components/common/HouseworkCatetoryTag/HouseworkCategoryTag';
 
 const meta = {
-  title: 'components/HouseworkCategoryTag',
+  title: 'components/common/HouseworkCategoryTag',
   component: HouseworkCategoryTag,
   tags: ['autodocs'],
 } satisfies Meta<typeof HouseworkCategoryTag>;

--- a/src/components/common/HouseworkCatetoryTag/HouseworkCategoryTag.stories.ts
+++ b/src/components/common/HouseworkCatetoryTag/HouseworkCategoryTag.stories.ts
@@ -1,0 +1,20 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import HouseworkCategoryTag, {
+  HouseworkCategoryTagProps,
+} from '@/components/common/HouseworkCatetoryTag/HouseworkCategoryTag';
+
+const meta = {
+  title: 'components/HouseworkCategoryTag',
+  component: HouseworkCategoryTag,
+  tags: ['autodocs'],
+} satisfies Meta<typeof HouseworkCategoryTag>;
+
+export default meta;
+
+type Story = StoryObj<HouseworkCategoryTagProps>;
+
+export const Default: Story = {
+  args: {
+    category: '거실',
+  },
+};

--- a/src/components/common/HouseworkCatetoryTag/HouseworkCategoryTag.tsx
+++ b/src/components/common/HouseworkCatetoryTag/HouseworkCategoryTag.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { Badge } from '@/components/ui/badge';
+
+export interface HouseworkCategoryTagProps {
+  /** 집안일 카테고리 */
+  category: string;
+}
+
+const HouseworkCategoryTag: React.FC<HouseworkCategoryTagProps> = ({ category }) => {
+  return (
+    <div>
+      <Badge variant={'secondary'} className='px-1 text-12'>
+        {category}
+      </Badge>
+    </div>
+  );
+};
+
+export default HouseworkCategoryTag;


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약

> 집안일 카테고리 태그 컴포넌트 추가

## 📌 이슈 넘버

> #56 

## 📝 작업 내용
> 위 내용과 동일

## 📸 스크린샷(선택)
![image](https://github.com/user-attachments/assets/93b923a0-a562-48f6-862f-e6fde1508c8b)

## 💬리뷰 요구사항(선택)

> 수정사항 있으면 말씀해주세요
