### PR TITLE
Feature/#59-그룹 옵션 컨테이너, 아이템 컴포넌트 추가

### DIFF
--- a/src/components/GroupOptionContainer/GroupOption/GroupOption.stories.ts
+++ b/src/components/GroupOptionContainer/GroupOption/GroupOption.stories.ts
@@ -1,0 +1,25 @@
+import GroupOption from '@/components/GroupOptionContainer/GroupOption/GroupOption';
+import type { Meta, StoryObj } from '@storybook/react';
+
+const meta = {
+  title: 'components/GroupOptionContainer/GroupOption',
+  component: GroupOption,
+  tags: ['autodocs'],
+} satisfies Meta<typeof GroupOption>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    groupName: '우리집',
+    isSelected: false,
+  },
+};
+
+export const Selected: Story = {
+  args: {
+    groupName: '우리집',
+    isSelected: true,
+  },
+};

--- a/src/components/GroupOptionContainer/GroupOption/GroupOption.tsx
+++ b/src/components/GroupOptionContainer/GroupOption/GroupOption.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+
+interface GroupOptionProps {
+  /** 그룹(방) 이름 */
+  groupName: string;
+  /** 선택 여부 */
+  isSelected?: boolean;
+}
+
+const GroupOption: React.FC<GroupOptionProps> = ({ groupName, isSelected }: GroupOptionProps) => {
+  return (
+    <li className='flex cursor-pointer items-center gap-x-2'>
+      <div className={`h-6 w-6 rounded-md ${isSelected ? 'bg-black01' : 'bg-gray02'}`}></div>
+      <div className={`text-14 ${isSelected ? 'text-black01' : 'text-gray02'}`}>{groupName}</div>
+    </li>
+  );
+};
+
+export default GroupOption;

--- a/src/components/GroupOptionContainer/GroupOptionContainer.stories.ts
+++ b/src/components/GroupOptionContainer/GroupOptionContainer.stories.ts
@@ -1,0 +1,12 @@
+import GroupOptionContainer from '@/components/GroupOptionContainer/GroupOptionContainer';
+import type { Meta, StoryObj } from '@storybook/react';
+
+const meta = {
+  title: 'components/GroupOptionContainer',
+  component: GroupOptionContainer,
+} satisfies Meta<typeof GroupOptionContainer>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/src/components/GroupOptionContainer/GroupOptionContainer.tsx
+++ b/src/components/GroupOptionContainer/GroupOptionContainer.tsx
@@ -1,0 +1,14 @@
+import GroupOption from '@/components/GroupOptionContainer/GroupOption/GroupOption';
+
+const GroupOptionContainer = () => {
+  const groups = ['우리집', '회사'];
+  return (
+    <ul className='flex flex-col gap-y-6 px-5 pb-14 pt-8'>
+      {groups.map(group => (
+        <GroupOption key={group} groupName={group} />
+      ))}
+    </ul>
+  );
+};
+
+export default GroupOptionContainer;


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약

> ex) 메인페이지 - 라우트 연결

그룹 옵션 컨테이너, 아이템 컴포넌트 퍼블리싱했습니다.

## 📌 이슈 넘버

> ex) #이슈번호, #이슈번호

#59 #19 

## 📝 작업 내용
퍼블리싱

## 📸 스크린샷(선택)
![image](https://github.com/user-attachments/assets/3b9f7882-ebd9-414b-ba9d-68e17328ab63)
![image](https://github.com/user-attachments/assets/6256c601-ba07-4975-831e-4254e2696c08)


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
