### PR TITLE
Feature/#58-프리셋 탭 컴포넌트 추가

### DIFF
--- a/src/components/PresetTabContainer/PresetTab/PresetTab.stories.tsx
+++ b/src/components/PresetTabContainer/PresetTab/PresetTab.stories.tsx
@@ -1,0 +1,34 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import PresetTab from './PresetTab';
+import { Tabs, TabsList, TabsContent } from '@/components/ui/tabs';
+
+const meta: Meta<typeof PresetTab> = {
+  title: 'Components/PresetTabContainer/PresetTab',
+  component: PresetTab,
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof PresetTab>;
+
+export const Default: Story = {
+  render: () => (
+    <Tabs defaultValue='living'>
+      <TabsList>
+        <PresetTab name='거실' value='living' icon='' />
+      </TabsList>
+      <TabsContent value='living'>선택</TabsContent>
+    </Tabs>
+  ),
+};
+
+export const CustomTab: Story = {
+  render: () => (
+    <Tabs defaultValue=''>
+      <TabsList>
+        <PresetTab name='주방' value='kitchen' icon='' />
+      </TabsList>
+      <TabsContent value='kitchen'>선택X</TabsContent>
+    </Tabs>
+  ),
+};

--- a/src/components/PresetTabContainer/PresetTab/PresetTab.tsx
+++ b/src/components/PresetTabContainer/PresetTab/PresetTab.tsx
@@ -1,0 +1,22 @@
+import { TabsTrigger } from '@/components/ui/tabs';
+import React from 'react';
+
+interface PresetTabProps {
+  name: string;
+  value: string;
+  icon: string;
+}
+
+const PresetTab: React.FC<PresetTabProps> = ({ name, value, icon }) => {
+  return (
+    <TabsTrigger
+      value={value}
+      className='flex gap-2 text-14 data-[state=active]:bg-black01 data-[state=inactive]:bg-white02 data-[state=active]:text-white03'
+    >
+      <div className='h-5 w-5 bg-gray03'>{icon}</div>
+      {name}
+    </TabsTrigger>
+  );
+};
+
+export default PresetTab;


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약

> 집안일 추가 - 집안일 선택 - 프리셋 탭

## 📌 이슈 넘버

> #41

## 📝 작업 내용
- 프리셋 탭 컴포넌트 추가

## 📸 스크린샷(선택)
![image](https://github.com/user-attachments/assets/b4152e22-9d3f-4361-ba18-6fd278ff48e9)
![image](https://github.com/user-attachments/assets/1846febb-44d4-46f2-be50-c540ff79afdd)


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
