### PR TITLE
Feature/#58-프리셋 탭 컨테이너

### DIFF
--- a/src/components/PresetTabContainer/PresetTabContainer.stories.tsx
+++ b/src/components/PresetTabContainer/PresetTabContainer.stories.tsx
@@ -1,0 +1,34 @@
+// PresetTabContainer.stories.tsx
+import type { Meta, StoryObj } from '@storybook/react';
+import PresetTabContainer from './PresetTabContainer';
+
+const meta: Meta<typeof PresetTabContainer> = {
+  title: 'Components/PresetTabContainer',
+  component: PresetTabContainer,
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof PresetTabContainer>;
+
+export const Default: Story = {
+  render: () => <PresetTabContainer />,
+};
+
+// 다른 상태나 변형을 보여주고 싶다면 추가 스토리를 작성할 수 있습니다
+export const WithContent: Story = {
+  render: () => (
+    <div className='max-w-2xl w-full'>
+      <PresetTabContainer />
+    </div>
+  ),
+};
+
+export const MultiplePresets: Story = {
+  render: () => (
+    <div className='space-y-4'>
+      <PresetTabContainer />
+      <PresetTabContainer />
+    </div>
+  ),
+};

--- a/src/components/PresetTabContainer/PresetTabContainer.tsx
+++ b/src/components/PresetTabContainer/PresetTabContainer.tsx
@@ -1,0 +1,24 @@
+import PresetTab from '@/components/PresetTabContainer/PresetTab/PresetTab';
+import { Tabs, TabsContent, TabsList } from '@/components/ui/tabs';
+
+const PRESET_TABS = [
+  { name: '전체', value: 'all', icon: '' },
+  { name: '거실', value: 'living', icon: '' },
+  { name: '주방', value: 'kitchen', icon: '' },
+  { name: '욕실', value: 'bathroom', icon: '' },
+  { name: '기타', value: 'etc', icon: '' },
+];
+
+const PresetTabContainer = () => {
+  return (
+    <Tabs defaultValue='all'>
+      <TabsList className='flex w-full justify-start gap-4 overflow-x-auto overflow-y-hidden bg-white03 p-0 no-scrollbar'>
+        {PRESET_TABS.map(tab => (
+          <PresetTab key={tab.value} name={tab.name} value={tab.value} icon={tab.icon} />
+        ))}
+      </TabsList>
+    </Tabs>
+  );
+};
+
+export default PresetTabContainer;


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약

> 집안일 추가 - 집안일 선택 - 프리셋 탭 컨테이너

## 📌 이슈 넘버

> #58 

## 📝 작업 내용
- 프리셋 탭 컨테이너 추

## 📸 스크린샷(선택)
![image](https://github.com/user-attachments/assets/d282b904-e549-4773-a943-8a255cf133f5)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
