### PR TITLE
Feature/#8-리스트 컨테이너 수정

### DIFF
--- a/src/components/ListContainer/ListContainer.stories.ts
+++ b/src/components/ListContainer/ListContainer.stories.ts
@@ -18,12 +18,13 @@ const data = [
     handleAction: () => {
       console.log('Action btn clicked for 거실 바닥 걸레질');
     },
-    listTitle: '거실 바닥 걸레질',
+    listTitle: '바닥 걸레질',
     charger: '종원',
     time: '오후 8:00',
     handleEditOrDelete: () => {
       console.log('Edit or Delete triggered for 거실 바닥 걸레질');
     },
+    category: '거실',
   },
   {
     id: 2,
@@ -31,12 +32,13 @@ const data = [
     handleAction: () => {
       console.log('Action btn clicked for 주방 청소');
     },
-    listTitle: '주방 청소',
+    listTitle: '청소',
     charger: '민수',
     time: '오후 9:00',
     handleEditOrDelete: () => {
       console.log('Edit or Delete triggered for 주방 청소');
     },
+    category: '주방',
   },
   {
     id: 3,
@@ -50,6 +52,7 @@ const data = [
     handleEditOrDelete: () => {
       console.log('Edit or Delete triggered for 세탁기 돌리기');
     },
+    category: '기타',
   },
   {
     id: 4,
@@ -63,6 +66,7 @@ const data = [
     handleEditOrDelete: () => {
       console.log('Edit or Delete triggered for 정리 정돈');
     },
+    category: '침실',
   },
 ];
 

--- a/src/components/ListContainer/ListItemContainer/ListItemContainer.stories.ts
+++ b/src/components/ListContainer/ListItemContainer/ListItemContainer.stories.ts
@@ -19,12 +19,13 @@ export const Default: Story = {
     handleAction: fn(() => {
       console.log('action btn clicked');
     }),
-    listTitle: '거실 바닥 걸레질',
+    listTitle: '바닥 걸레질',
     charger: '종원',
     time: '오후 8:00',
     handleEditOrDelete: fn(() => {
       console.log('Edit or Delete triggered');
     }),
+    category: '거실',
   },
 };
 
@@ -35,11 +36,12 @@ export const Complete: Story = {
     handleAction: fn(() => {
       console.log('action btn clicked');
     }),
-    listTitle: '화장실 청소',
+    listTitle: '청소',
     charger: '철수',
     time: '오후 9:00',
     handleEditOrDelete: fn(() => {
       console.log('Edit or Delete triggered');
     }),
+    category: '화장실',
   },
 };

--- a/src/components/ListContainer/ListItemContainer/ListItemContainer.tsx
+++ b/src/components/ListContainer/ListItemContainer/ListItemContainer.tsx
@@ -35,7 +35,7 @@ const ListItemContainer: React.FC<ListItemContainerProps> = ({
       <ListActionBtn actionStatus={actionStatus} handleAction={handleAction} />
       <div className='flex w-full justify-between'>
         <div className='flex flex-col items-start justify-center'>
-          <div className='flex'>
+          <div className='flex items-center'>
             <p className={`text-18 ${actionStatus === 'complete' && 'line-through'}`}>
               {listTitle}
             </p>

--- a/src/components/ListContainer/ListItemContainer/ListItemContainer.tsx
+++ b/src/components/ListContainer/ListItemContainer/ListItemContainer.tsx
@@ -1,8 +1,14 @@
 import React from 'react';
 import EditDeleteBtn, { EditDeleteBtnProps } from '../EditDeleteBtn/EditDeleteBtn';
 import ListActionBtn, { ListActionBtnProps } from '../ListActionBtn/ListActionBtn';
+import HouseworkCategoryTag, {
+  HouseworkCategoryTagProps,
+} from '@/components/common/HouseworkCatetoryTag/HouseworkCategoryTag';
 
-export interface ListItemContainerProps extends ListActionBtnProps, EditDeleteBtnProps {
+export interface ListItemContainerProps
+  extends ListActionBtnProps,
+    EditDeleteBtnProps,
+    HouseworkCategoryTagProps {
   /** 집안일 ID */
   id: number;
   /** 집안일 */
@@ -20,6 +26,7 @@ const ListItemContainer: React.FC<ListItemContainerProps> = ({
   charger,
   time,
   handleEditOrDelete,
+  category,
 }) => {
   return (
     <li
@@ -28,7 +35,13 @@ const ListItemContainer: React.FC<ListItemContainerProps> = ({
       <ListActionBtn actionStatus={actionStatus} handleAction={handleAction} />
       <div className='flex w-full justify-between'>
         <div className='flex flex-col items-start justify-center'>
-          <p className={`text-18 ${actionStatus === 'complete' && 'line-through'}`}>{listTitle}</p>
+          <div className='flex'>
+            <p className={`text-18 ${actionStatus === 'complete' && 'line-through'}`}>
+              {listTitle}
+            </p>
+            <HouseworkCategoryTag category={category} status={actionStatus} isDark={true} />
+          </div>
+
           <p className='text-12'>{charger}</p>
         </div>
         <div className='flex flex-col items-end justify-center'>

--- a/src/components/common/HouseworkCatetoryTag/HouseworkCategoryTag.tsx
+++ b/src/components/common/HouseworkCatetoryTag/HouseworkCategoryTag.tsx
@@ -4,12 +4,22 @@ import { Badge } from '@/components/ui/badge';
 export interface HouseworkCategoryTagProps {
   /** 집안일 카테고리 */
   category: string;
+  /** 상태 */
+  status?: string;
+  isDark?: boolean;
 }
 
-const HouseworkCategoryTag: React.FC<HouseworkCategoryTagProps> = ({ category }) => {
+const HouseworkCategoryTag: React.FC<HouseworkCategoryTagProps> = ({
+  category,
+  status,
+  isDark,
+}) => {
   return (
     <div>
-      <Badge variant={'secondary'} className='px-1 text-12'>
+      <Badge
+        variant={'secondary'}
+        className={`px-1 text-12 ${isDark && 'dark'} ${status === 'complete' && 'border-none bg-gray02'}`}
+      >
         {category}
       </Badge>
     </div>


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약

- 집안일 카테고리 태그 props 수정
- 리스트 아이템 컨테이너 수정
- 리스트 컨테이너 수정

## 📌 이슈 넘버

> #8 #9  #56 

## 📝 작업 내용
- 집안일 카테고리 태그는 상태에 따른 색 변화
- 리스트 아이템 컨테이너에 집안일 카테고리 태그 삽입
- 리스트 컨테이너 스토리북 문서에 더미 데이터 수정

## 📸 스크린샷(선택)
![image](https://github.com/user-attachments/assets/1dc19719-3cea-4ac2-ae71-88c714745a26)


## 💬리뷰 요구사항(선택)

> 수정할 사항 있으면 말씀해주세요!
