### PR TITLE
feature/#49-add-managerSelectContainer

### DIFF
--- a/src/components/ManagerSelectContainer/ManagerSelectContainer.stories.ts
+++ b/src/components/ManagerSelectContainer/ManagerSelectContainer.stories.ts
@@ -1,0 +1,12 @@
+import ManagerSelectContainer from '@/components/ManagerSelectContainer/ManagerSelectContainer';
+import type { Meta, StoryObj } from '@storybook/react';
+
+const meta = {
+  title: 'components/ManagerSelectContainer',
+  component: ManagerSelectContainer,
+} satisfies Meta<typeof ManagerSelectContainer>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/src/components/ManagerSelectContainer/ManagerSelectContainer.tsx
+++ b/src/components/ManagerSelectContainer/ManagerSelectContainer.tsx
@@ -1,0 +1,14 @@
+import ManagerSelectItem from '@/components/ManagerSelectContainer/ManagerSelectItem/ManagerSelectItem';
+
+const MaganerSelectContainer = () => {
+  const members = ['김민수', '이영희', '박지수', '최수진'];
+  return (
+    <ul className='flex flex-col gap-y-4 px-5 pb-14 pt-8'>
+      {members.map(member => (
+        <ManagerSelectItem key={member} name={member} />
+      ))}
+    </ul>
+  );
+};
+
+export default MaganerSelectContainer;


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약

> ex) 메인페이지 - 라우트 연결

집안일 담당자를 선택할때 사용하는 컨테이너입니다.

## 📌 이슈 넘버

> ex) #이슈번호, #이슈번호

#49 

## 📝 작업 내용

## 📸 스크린샷(선택)

![image](https://github.com/user-attachments/assets/ca416501-c6ab-40b0-be0f-372b26bca958)


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
