### PR TITLE
Feature/#53-공통 버튼 컨테이너 추가

### DIFF
--- a/src/components/common/ButtonContainer/ButtonContainer.stories.ts
+++ b/src/components/common/ButtonContainer/ButtonContainer.stories.ts
@@ -9,20 +9,10 @@ const meta = {
     buttonLeft: {
       control: 'object',
       description: '왼쪽 버튼의 속성 설정',
-      table: {
-        type: {
-          summary: `{ label: string; variant: 'full' | 'outline' | 'secondary' | 'ghost' | 'link'; size: 'small' | 'medium' | 'large'; }`,
-        },
-      },
     },
     buttonRight: {
       control: 'object',
       description: '오른쪽 버튼의 속성 설정',
-      table: {
-        type: {
-          summary: `{ label: string; variant: 'full' | 'outline' | 'secondary' | 'ghost' | 'link'; size: 'small' | 'medium' | 'large'; }`,
-        },
-      },
     },
   },
 } satisfies Meta<typeof ButtonContainer>;

--- a/src/components/common/ButtonContainer/ButtonContainer.stories.ts
+++ b/src/components/common/ButtonContainer/ButtonContainer.stories.ts
@@ -1,0 +1,46 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import ButtonContainer from './ButtonContainer';
+
+const meta = {
+  title: 'components/common/ButtonContainer/ButtonContainer',
+  component: ButtonContainer,
+  tags: ['autodocs'],
+  argTypes: {
+    buttonLeft: {
+      control: 'object',
+      description: '왼쪽 버튼의 속성 설정',
+      table: {
+        type: {
+          summary: `{ label: string; variant: 'full' | 'outline' | 'secondary' | 'ghost' | 'link'; size: 'small' | 'medium' | 'large'; }`,
+        },
+      },
+    },
+    buttonRight: {
+      control: 'object',
+      description: '오른쪽 버튼의 속성 설정',
+      table: {
+        type: {
+          summary: `{ label: string; variant: 'full' | 'outline' | 'secondary' | 'ghost' | 'link'; size: 'small' | 'medium' | 'large'; }`,
+        },
+      },
+    },
+  },
+} satisfies Meta<typeof ButtonContainer>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    buttonLeft: {
+      label: '설정',
+      variant: 'outline',
+      size: 'small',
+    },
+    buttonRight: {
+      label: '선택 완료',
+      variant: 'full',
+      size: 'medium',
+    },
+  },
+};

--- a/src/components/common/ButtonContainer/ButtonContainer.tsx
+++ b/src/components/common/ButtonContainer/ButtonContainer.tsx
@@ -1,0 +1,27 @@
+import Button from '@/components/common/ButtonContainer/Button/Button';
+
+interface ButtonContainerProps {
+  /** 좌측 버튼 */
+  buttonLeft: {
+    label: string;
+    variant: 'full' | 'outline' | 'secondary' | 'ghost' | 'link';
+    size: 'small' | 'medium' | 'large';
+  };
+  /** 우측 버튼 */
+  buttonRight: {
+    label: string;
+    variant: 'full' | 'outline' | 'secondary' | 'ghost' | 'link';
+    size: 'small' | 'medium' | 'large';
+  };
+}
+
+const ButtonContainer = ({ buttonLeft, buttonRight }: ButtonContainerProps) => {
+  return (
+    <div className='flex items-center gap-2'>
+      <Button {...buttonLeft} />
+      <Button {...buttonRight} />
+    </div>
+  );
+};
+
+export default ButtonContainer;


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약

> 공통 버튼 컨테이너 추가

## 📌 이슈 넘버

> #53 

## 📝 작업 내용
- 공통 버튼 컨테이너 추가
- 공통 버튼 컨테이너 스토리북 문서 추가

## 📸 스크린샷(선택)
![image](https://github.com/user-attachments/assets/5a5871e7-5d14-4569-aa89-ff83d845eecb)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
