### PR TITLE
Feature/#48-텍스트 태그 컴포넌트 추가

### DIFF
--- a/src/components/common/TextTag/TextTag.stories.ts
+++ b/src/components/common/TextTag/TextTag.stories.ts
@@ -1,0 +1,26 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import TextTag from '@/components/common/TextTag/TextTag';
+
+const meta = {
+  title: 'components/common/TextTag',
+  component: TextTag,
+  tags: ['autodocs'],
+} satisfies Meta<typeof TextTag>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    type: 'darkfill',
+    label: '담당자',
+  },
+};
+
+export const GrayFill: Story = {
+  args: {
+    type: 'grayfill',
+    label: '담당자',
+  },
+};

--- a/src/components/common/TextTag/TextTag.tsx
+++ b/src/components/common/TextTag/TextTag.tsx
@@ -1,0 +1,14 @@
+import { Badge } from '@/components/ui/badge';
+
+interface TextTagProps {
+  /** 타입 */
+  type: 'darkfill' | 'grayfill';
+  /** 라벨 */
+  label: string;
+}
+
+const TextTag = ({ type, label }: TextTagProps) => {
+  return <Badge variant={type}>{label}</Badge>;
+};
+
+export default TextTag;

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -1,36 +1,35 @@
-import * as React from "react"
-import { cva, type VariantProps } from "class-variance-authority"
+import * as React from 'react';
+import { cva, type VariantProps } from 'class-variance-authority';
 
-import { cn } from "@/lib/utils"
+import { cn } from '@/lib/utils';
 
 const badgeVariants = cva(
-  "inline-flex items-center rounded-md border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
+  'inline-flex items-center rounded-md border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2',
   {
     variants: {
       variant: {
-        default:
-          "border-transparent bg-primary text-primary-foreground shadow hover:bg-primary/80",
+        default: 'border-transparent bg-primary text-primary-foreground shadow hover:bg-primary/80',
         secondary:
-          "border-transparent bg-secondary text-secondary-foreground hover:bg-secondary/80",
+          'border-transparent bg-secondary text-secondary-foreground hover:bg-secondary/80',
         destructive:
-          "border-transparent bg-destructive text-destructive-foreground shadow hover:bg-destructive/80",
-        outline: "text-foreground",
+          'border-transparent bg-destructive text-destructive-foreground shadow hover:bg-destructive/80',
+        outline: 'text-foreground',
+        darkfill: 'border-transparent bg-black01 text-white01 px-4 py-2 rounded-lg font-medium',
+        grayfill: 'border-transparent bg-black02 text-white01 px-4 py-2 rounded-lg font-medium',
       },
     },
     defaultVariants: {
-      variant: "default",
+      variant: 'default',
     },
   }
-)
+);
 
 export interface BadgeProps
   extends React.HTMLAttributes<HTMLDivElement>,
     VariantProps<typeof badgeVariants> {}
 
 function Badge({ className, variant, ...props }: BadgeProps) {
-  return (
-    <div className={cn(badgeVariants({ variant }), className)} {...props} />
-  )
+  return <div className={cn(badgeVariants({ variant }), className)} {...props} />;
 }
 
-export { Badge, badgeVariants }
+export { Badge, badgeVariants };


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약

> 텍스트 태그 컴포넌트 추가

## 📌 이슈 넘버

> #48 

## 📝 작업 내용
- /ui/badge 컴포넌트 스타일변수 추가 'darkfill, grayfill'
- 텍스트 태그 컴포넌트 추가
- 텍스트 태그 컴포넌트 스토리북 문서 추가

## 📸 스크린샷(선택)
![image](https://github.com/user-attachments/assets/d38654a8-7e12-4899-a06b-da3a6aec3d6e)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
