### PR TITLE
Feature/#46-HouseWorkSelectBtn(선택전) 퍼블리싱

### DIFF
--- a/src/components/HouseWorkSelectBtn/HouseWorkSelectBtn.stories.ts
+++ b/src/components/HouseWorkSelectBtn/HouseWorkSelectBtn.stories.ts
@@ -1,0 +1,13 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import HouseWorkSelectBtn from '@/components/HouseWorkSelectBtn/HouseWorkSelectBtn';
+
+const meta = {
+  title: 'components/HouseWorkSelectBtn',
+  component: HouseWorkSelectBtn,
+  tags: ['autodocs'],
+} satisfies Meta<typeof HouseWorkSelectBtn>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/src/components/HouseWorkSelectBtn/HouseWorkSelectBtn.tsx
+++ b/src/components/HouseWorkSelectBtn/HouseWorkSelectBtn.tsx
@@ -1,0 +1,12 @@
+import { Button } from '@/components/ui/button';
+
+const HouseWorkSelectBtn = () => {
+  return (
+    <Button variant='houseWorkSelect' size='full' className='!justify-between'>
+      <div>어떤 집안일인가요?</div>
+      <div className='h-4 w-4 rounded-full bg-gray02'></div>
+    </Button>
+  );
+};
+
+export default HouseWorkSelectBtn;

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -16,11 +16,14 @@ const buttonVariants = cva(
           'bg-gray03 text-secondary-foreground shadow-sm hover:bg-secondary/80 text-white02',
         ghost: 'hover:bg-accent hover:text-accent-foreground',
         link: 'text-primary underline-offset-4 hover:underline',
+        houseWorkSelect:
+          'border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground text-black01 px-3 py-4 rounded-2xl',
       },
       size: {
         small: 'h-15 max-w-[89px] rounded-xl px-8 py-4',
         medium: 'h-15 max-w-[250px] rounded-xl px-24 py-4',
         large: 'h-15 max-w-[350px] rounded-xl px-40 py-4',
+        full: 'w-full',
       },
     },
     defaultVariants: {


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약

> ex) 메인페이지 - 라우트 연결

집안일 선택 버튼 퍼블리싱했습니다.

## 📌 이슈 넘버

> ex) #이슈번호, #이슈번호

#46 

## 📝 작업 내용

퍼블리싱

## 📸 스크린샷(선택)

![image](https://github.com/user-attachments/assets/0c9af45a-eac0-4e80-8f17-3ac6e8319dc1)


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
