### PR TITLE
Feature/#55-HouseWorkSelectedBtn 퍼블리싱

### DIFF
--- a/src/components/HouseWorkSelectedBtn/HouseWorkSelectedBtn.stories.ts
+++ b/src/components/HouseWorkSelectedBtn/HouseWorkSelectedBtn.stories.ts
@@ -1,0 +1,17 @@
+import HouseWorkSelectedBtn from '@/components/HouseWorkSelectedBtn/HouseWorkSelectedBtn';
+import type { Meta, StoryObj } from '@storybook/react';
+
+const meta = {
+  title: 'components/HouseWorkSelectedBtn',
+  component: HouseWorkSelectedBtn,
+  tags: ['autodocs'],
+} satisfies Meta<typeof HouseWorkSelectedBtn>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    houseWork: '음식물 쓰레기 처리',
+  },
+};

--- a/src/components/HouseWorkSelectedBtn/HouseWorkSelectedBtn.tsx
+++ b/src/components/HouseWorkSelectedBtn/HouseWorkSelectedBtn.tsx
@@ -1,0 +1,18 @@
+import { Button } from '@/components/ui/button';
+
+interface HouseWorkSelectedBtnProps {
+  /**선택된 집안일 */
+  houseWork: string;
+}
+const HouseWorkSelectedBtn: React.FC<HouseWorkSelectedBtnProps> = ({ houseWork }) => {
+  return (
+    <div className='flex items-center gap-x-11'>
+      <div className='w-auto whitespace-nowrap'>집안일</div>
+      <Button variant='houseWorkSelect' size='full' className='text-gray02'>
+        {houseWork}
+      </Button>
+    </div>
+  );
+};
+
+export default HouseWorkSelectedBtn;


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약

> ex) 메인페이지 - 라우트 연결

집안일 선택되고 나서 나타나는 버튼입니다.

## 📌 이슈 넘버

> ex) #이슈번호, #이슈번호

#55 

## 📝 작업 내용

퍼블리싱

## 📸 스크린샷(선택)

![image](https://github.com/user-attachments/assets/59437ae1-313f-4927-a9f3-8edb3e41f608)


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
