### PR TITLE
Feature/#42-수정삭제 드롭다운 컴포넌트 추가

### DIFF
--- a/src/components/ControlDropdown/ControlDropdown.stories.ts
+++ b/src/components/ControlDropdown/ControlDropdown.stories.ts
@@ -1,0 +1,20 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { action } from '@storybook/addon-actions';
+import ControlDropdown from '@/components/ControlDropdown/ControlDropdown';
+
+const meta = {
+  title: 'components/ControlDropdown/ControlDropdown',
+  component: ControlDropdown,
+  tags: ['autodocs'],
+  argTypes: {},
+} satisfies Meta<typeof ControlDropdown>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    handleEdit: action('Edit button clicked'),
+    handleDelete: action('Delete button clicked'),
+  },
+};

--- a/src/components/ControlDropdown/ControlDropdown.tsx
+++ b/src/components/ControlDropdown/ControlDropdown.tsx
@@ -1,0 +1,40 @@
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+
+interface ControlDropdownProps {
+  /** 수정 클릭 이벤트 */
+  handleEdit: () => void;
+  /** 삭제 클릭 이벤트 */
+  handleDelete: () => void;
+}
+
+const ControlDropdown = ({ handleEdit, handleDelete }: ControlDropdownProps) => {
+  return (
+    <DropdownMenu>
+      {/* TODO Trigger 수정 필요 */}
+      <DropdownMenuTrigger>선택</DropdownMenuTrigger>
+      <DropdownMenuContent className='flex flex-col rounded-2xl'>
+        <DropdownMenuItem
+          className='flex items-center justify-between px-5 py-2 text-14'
+          onSelect={handleEdit}
+        >
+          <span className='border-gray-300 border px-2 py-2'>{/* 아이콘 자리 */}</span>
+          수정
+        </DropdownMenuItem>
+        <DropdownMenuItem
+          className='flex items-center justify-between px-5 py-2 text-14'
+          onSelect={handleDelete}
+        >
+          <span className='border-gray-300 border px-2 py-2'>{/* 아이콘 자리 */}</span>
+          삭제
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+};
+
+export default ControlDropdown;


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약

> 수정삭제 드롭다운 컴포넌트 추가

## 📌 이슈 넘버

> #42 

## 📝 작업 내용
- 수정삭제 드롭다운 컴포넌트 추가 (아이콘 제외)
- 수정삭제 드롭다운 컴포넌트 스토리북 문서 추가

## 📸 스크린샷(선택)
![image](https://github.com/user-attachments/assets/cf8e25e5-8e81-419c-8df1-5e804e273441)


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
