### PR TITLE
Feature/#89-바텀시트 > 그룹 변경 컴포넌트 추가

### DIFF
--- a/src/components/HomeHeaderContainer/GroupSelectBtn/GroupSelectBtn.tsx
+++ b/src/components/HomeHeaderContainer/GroupSelectBtn/GroupSelectBtn.tsx
@@ -1,4 +1,6 @@
-import React from 'react';
+import BottomSheetContainer from '@/components/common/BottomSheetContainer/BottomSheetContainer';
+import GroupOptionContainer from '@/components/GroupOptionContainer/GroupOptionContainer';
+import React, { useState } from 'react';
 
 interface GroupSelectBtnProps {
   /** 현재 속해있는 그룹명 */
@@ -6,11 +8,25 @@ interface GroupSelectBtnProps {
 }
 
 const GroupSelectBtn: React.FC<GroupSelectBtnProps> = ({ groupName }: GroupSelectBtnProps) => {
+  const [isOpen, setOpen] = useState(false);
+
+  const handleClick = () => {
+    setOpen(true);
+  };
   return (
-    <button className='bg-gray03 text-12 text-white03 flex items-center rounded-full px-2 py-1'>
-      <div className='bg-gray01 h-4 w-4 rounded-full'></div>
-      <div className='pl-2'>{groupName}</div>
-    </button>
+    <>
+      <button
+        className='text-12 flex items-center rounded-full bg-gray03 px-2 py-1 text-white03'
+        onClick={handleClick}
+      >
+        <div className='h-4 w-4 rounded-full bg-gray01'></div>
+        <div className='pl-2'>{groupName}</div>
+      </button>
+
+      <BottomSheetContainer isOpen={isOpen} setOpen={setOpen} title='그룹 변경'>
+        <GroupOptionContainer />
+      </BottomSheetContainer>
+    </>
   );
 };
 

--- a/src/components/common/BottomSheetContainer/BottomSheetContainer.tsx
+++ b/src/components/common/BottomSheetContainer/BottomSheetContainer.tsx
@@ -1,14 +1,28 @@
 import { Sheet } from 'react-modal-sheet';
-import { useState } from 'react';
 import BottomSheetCloseBtn from './BottomSheetCloseBtn/BottomSheetCloseBtn';
 import BottomSheetTitle from './BottomSheetTitle/BottomSheetTitle';
 
-const BottomSheetContainer = () => {
-  const [isOpen, setOpen] = useState(false);
+import React from 'react';
+
+interface BottomSheetContainerProps {
+  /**바텀시트 오픈 여부 */
+  isOpen: boolean;
+  /**isOpen 바꾸는 set함수 */
+  setOpen: (value: boolean) => void;
+  /**바텀시트 타이틀 */
+  title: string;
+  /**바텀시트 컨텐츠 */
+  children: React.ReactNode;
+}
+
+const BottomSheetContainer: React.FC<BottomSheetContainerProps> = ({
+  isOpen,
+  setOpen,
+  title,
+  children,
+}) => {
   return (
     <>
-      <button onClick={() => setOpen(true)}>Open sheet</button>
-
       <Sheet
         isOpen={isOpen}
         onClose={() => setOpen(false)}
@@ -19,11 +33,9 @@ const BottomSheetContainer = () => {
           <Sheet.Container>
             <BottomSheetCloseBtn handleClick={() => setOpen(false)} />
             <Sheet.Header>
-              <BottomSheetTitle title='모임 변경' />
+              <BottomSheetTitle title={title} />
             </Sheet.Header>
-            <Sheet.Content>
-              <div className='px-5 py-8'>Some content</div>
-            </Sheet.Content>
+            <Sheet.Content>{children}</Sheet.Content>
           </Sheet.Container>
         </div>
         <Sheet.Backdrop />


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약

> ex) 메인페이지 - 라우트 연결

그룹 변경 바텀시트를 만들었습니다.

## 📌 이슈 넘버

> ex) #이슈번호, #이슈번호

#89 

## 📝 작업 내용

## 📸 스크린샷(선택)
<img width="321" alt="화면 캡처 2024-11-25 163119" src="https://github.com/user-attachments/assets/3115c7a2-1447-451b-abd4-bdd446e4cfb0">


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
