### PR TITLE
Feature/#93 집안일 추가 바텀 시트 컨테이너

### DIFF
--- a/src/components/PresetTabContainer/PresetTabContainer.tsx
+++ b/src/components/PresetTabContainer/PresetTabContainer.tsx
@@ -1,22 +1,46 @@
+import PresetItem from '@/components/common/PresetItem/PresetItem';
 import PresetTab from '@/components/PresetTabContainer/PresetTab/PresetTab';
 import { Tabs, TabsContent, TabsList } from '@/components/ui/tabs';
 
-const PRESET_TABS = [
-  { name: '전체', value: 'all', icon: '' },
-  { name: '거실', value: 'living', icon: '' },
-  { name: '주방', value: 'kitchen', icon: '' },
-  { name: '욕실', value: 'bathroom', icon: '' },
-  { name: '기타', value: 'etc', icon: '' },
-];
+interface PresetItem {
+  id: number;
+  description: string;
+}
 
-const PresetTabContainer = () => {
+interface PresetData {
+  category: string;
+  items: PresetItem[];
+}
+
+interface PresetTabContainerProps {
+  data: PresetData[];
+}
+
+const PresetTabContainer: React.FC<PresetTabContainerProps> = ({ data }) => {
+  const handleClick = (item: string) => {
+    console.log(item);
+  };
+
   return (
-    <Tabs defaultValue='all'>
-      <TabsList className='flex w-full justify-start gap-4 overflow-x-auto overflow-y-hidden bg-white03 p-0 no-scrollbar'>
-        {PRESET_TABS.map(tab => (
-          <PresetTab key={tab.value} name={tab.name} value={tab.value} icon={tab.icon} />
+    <Tabs defaultValue={data[0]?.category}>
+      <TabsList className='flex w-full justify-start gap-4 overflow-x-auto overflow-y-hidden bg-white03 p-0 px-5 no-scrollbar'>
+        {data.map((tab, index) => (
+          <PresetTab key={index} name={tab.category} value={tab.category} icon='' />
         ))}
       </TabsList>
+      {data.map(tabData => (
+        <TabsContent key={tabData.category} value={tabData.category}>
+          {tabData.items.map(item => (
+            <div key={item.id}>
+              <PresetItem
+                category={tabData.category}
+                housework={item.description}
+                handleClick={() => handleClick(item.description)}
+              />
+            </div>
+          ))}
+        </TabsContent>
+      ))}
     </Tabs>
   );
 };

--- a/src/components/bottomSheet/HouseWorkSheetContainer/HouseWorkSheetContainer.stories.tsx
+++ b/src/components/bottomSheet/HouseWorkSheetContainer/HouseWorkSheetContainer.stories.tsx
@@ -1,0 +1,16 @@
+import HouseWorkSheetContainer from '@/components/bottomSheet/HouseWorkSheetContainer/HouseWorkSheetContainer';
+import type { Meta, StoryObj } from '@storybook/react';
+
+const meta = {
+  title: 'components/common/bottomSheet/HouseWorkSheetContainer',
+  component: HouseWorkSheetContainer,
+  tags: ['autodocs'],
+} satisfies Meta<typeof HouseWorkSheetContainer>;
+
+export default meta;
+
+type Story = StoryObj<typeof HouseWorkSheetContainer>;
+
+export const Default: Story = {
+  args: {},
+};

--- a/src/components/bottomSheet/HouseWorkSheetContainer/HouseWorkSheetContainer.tsx
+++ b/src/components/bottomSheet/HouseWorkSheetContainer/HouseWorkSheetContainer.tsx
@@ -1,0 +1,58 @@
+import BottomSheetContainer from '@/components/common/BottomSheetContainer/BottomSheetContainer';
+import PresetTabContainer from '@/components/PresetTabContainer/PresetTabContainer';
+import { useState } from 'react';
+
+interface PresetData {
+  category: string;
+  items: {
+    id: number;
+    description: string;
+  }[];
+}
+
+interface HouseWorkSheetContainerProps {}
+
+const HouseWorkSheetContainer: React.FC<HouseWorkSheetContainerProps> = ({}) => {
+  const [isOpen, setOpen] = useState(true);
+
+  const presetData: PresetData[] = [
+    {
+      category: '거실',
+      items: [
+        { id: 1, description: '매일 아침 화장실 청소하기' },
+        { id: 2, description: '거실 바닥 청소하기' },
+        { id: 3, description: '거실 청소기 돌리기' },
+      ],
+    },
+    {
+      category: '부엌',
+      items: [
+        { id: 4, description: '아침 식사 후 설거지하기' },
+        { id: 5, description: '저녁 식사 후 설거지하기' },
+        { id: 6, description: '오븐 청소' },
+      ],
+    },
+    {
+      category: '1번 방',
+      items: [{ id: 7, description: '1번 방 청소' }],
+    },
+    {
+      category: '2번 방',
+      items: [{ id: 8, description: '2번 방 청소' }],
+    },
+    {
+      category: '3번 방',
+      items: [{ id: 9, description: '3번 방 청소' }],
+    },
+  ];
+
+  return (
+    <BottomSheetContainer isOpen={isOpen} setOpen={setOpen} title='집안일 선택'>
+      <div className='mt-4 flex min-h-96 flex-col gap-y-6 pb-6'>
+        <PresetTabContainer data={presetData} />
+      </div>
+    </BottomSheetContainer>
+  );
+};
+
+export default HouseWorkSheetContainer;


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약

> 집안일 추가 페이지 - 집안일 할당 바텀 시트

## 📌 이슈 넘버

> #93

## 📝 작업 내용
- PresetTabsContainer props처리 수정
- houseWorkSheetContainer 추가

## 📸 스크린샷(선택)
![image](https://github.com/user-attachments/assets/ece5a073-c530-4314-afa2-38540147f248)


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
