### PR TITLE
Feature/#93 집안일 할당 바텀 시트 처리 완료

### DIFF
--- a/src/components/bottomSheet/HouseWorkSheetContainer/HouseWorkSheetContainer.tsx
+++ b/src/components/bottomSheet/HouseWorkSheetContainer/HouseWorkSheetContainer.tsx
@@ -1,57 +1,86 @@
 import BottomSheetContainer from '@/components/common/BottomSheetContainer/BottomSheetContainer';
 import ButtonContainer from '@/components/common/ButtonContainer/ButtonContainer';
+import TabContainer from '@/components/common/TabContainer/TabContainer';
 import PresetTabContainer from '@/components/PresetTabContainer/PresetTabContainer';
 import { useState } from 'react';
-
-interface PresetData {
-  category: string;
-  items: {
-    id: number;
-    description: string;
-  }[];
-}
 
 interface HouseWorkSheetContainerProps {}
 
 const HouseWorkSheetContainer: React.FC<HouseWorkSheetContainerProps> = ({}) => {
   const [isOpen, setOpen] = useState(true);
 
-  const presetData: PresetData[] = [
-    {
-      category: '거실',
-      items: [
-        { id: 1, description: '매일 아침 화장실 청소하기' },
-        { id: 2, description: '거실 바닥 청소하기' },
-        { id: 3, description: '거실 청소기 돌리기' },
-      ],
-    },
-    {
-      category: '부엌',
-      items: [
-        { id: 4, description: '아침 식사 후 설거지하기' },
-        { id: 5, description: '저녁 식사 후 설거지하기' },
-        { id: 6, description: '오븐 청소' },
-      ],
-    },
-    {
-      category: '1번 방',
-      items: [{ id: 7, description: '1번 방 청소' }],
-    },
-    {
-      category: '2번 방',
-      items: [{ id: 8, description: '2번 방 청소' }],
-    },
-    {
-      category: '3번 방',
-      items: [{ id: 9, description: '3번 방 청소' }],
-    },
-  ];
+  const mockData = {
+    userData: [
+      {
+        category: '거실',
+        items: [{ id: 1, description: '매일 아침 화장실 청소하기' }],
+      },
+      {
+        category: '부엌',
+        items: [{ id: 2, description: '아침 식사 후 설거지하기' }],
+      },
+      {
+        category: '1번 방',
+        items: [{ id: 3, description: '1번 방 바닥 청소' }],
+      },
+      {
+        category: '2번 방',
+        items: [{ id: 4, description: '2번 방 옷장 정리' }],
+      },
+      {
+        category: '3번 방',
+        items: [{ id: 5, description: '3번 방 나가기' }],
+      },
+    ],
+    presetData: [
+      {
+        category: '거실',
+        items: [
+          { id: 1, description: '매일 아침 화장실 청소하기' },
+          { id: 2, description: '거실 바닥 청소하기' },
+          { id: 3, description: '거실 청소기 돌리기' },
+        ],
+      },
+      {
+        category: '부엌',
+        items: [
+          { id: 4, description: '아침 식사 후 설거지하기' },
+          { id: 5, description: '저녁 식사 후 설거지하기' },
+          { id: 6, description: '오븐 청소' },
+        ],
+      },
+      {
+        category: '1번 방',
+        items: [{ id: 7, description: '1번 방 청소' }],
+      },
+      {
+        category: '2번 방',
+        items: [{ id: 8, description: '2번 방 청소' }],
+      },
+      {
+        category: '3번 방',
+        items: [{ id: 9, description: '3번 방 청소' }],
+      },
+    ],
+  };
+
+  const [activeTab, setActiveTab] = useState<string>('사용자 정의');
+  const chargers = Object.keys(mockData).map(key => ({
+    name: key === 'userData' ? '사용자 정의' : '프리셋',
+  }));
 
   return (
     <BottomSheetContainer isOpen={isOpen} setOpen={setOpen} title='집안일 선택'>
       <div className='mt-4 flex min-h-96 flex-col gap-y-6 pb-6'>
         <section aria-label='집안일 할당 바텀 시트' className='flex flex-1 flex-col gap-6'>
-          <PresetTabContainer data={presetData} />
+          <TabContainer
+            activeTab={activeTab}
+            handleSetActiveTab={setActiveTab}
+            chargers={chargers}
+          />
+          <PresetTabContainer
+            data={activeTab === '사용자 정의' ? mockData.userData : mockData.presetData}
+          />
         </section>
         <div className='px-5'>
           <ButtonContainer

--- a/src/components/common/TabContainer/Tab/Tab.tsx
+++ b/src/components/common/TabContainer/Tab/Tab.tsx
@@ -10,7 +10,7 @@ const Tab: React.FC<TabProps> = ({ name, value }) => {
   return (
     <TabsTrigger
       value={value}
-      className='rounded-none px-6 py-2 text-14 data-[state=active]:border-b-2 data-[state=active]:border-black01 data-[state=active]:shadow-none'
+      className='rounded-none px-6 py-2 text-14 data-[state=active]:border-b-4 data-[state=active]:border-black01 data-[state=active]:shadow-none'
     >
       {name}
     </TabsTrigger>

--- a/src/components/common/TabContainer/TabContainer.tsx
+++ b/src/components/common/TabContainer/TabContainer.tsx
@@ -2,26 +2,22 @@ import React from 'react';
 import Tab from '@/components/common/TabContainer/Tab/Tab';
 import { Tabs, TabsList } from '@/components/ui/tabs';
 
-const DUMMY_MEMBERS = [
-  { name: '전체', value: 'all' },
-  { name: '홍길동', value: 'hong' },
-  { name: '김철수', value: 'kim' },
-  { name: '이영희', value: 'lee' },
-  { name: '박지성', value: 'park' },
-  { name: '최민수', value: 'choi' },
-];
+interface Charger {
+  name: string;
+}
 
 interface TabContainerProps {
   activeTab: string;
   handleSetActiveTab: React.Dispatch<React.SetStateAction<string>>;
+  chargers: Charger[];
 }
 
-const TabContainer: React.FC<TabContainerProps> = ({ activeTab, handleSetActiveTab }) => {
+const TabContainer: React.FC<TabContainerProps> = ({ activeTab, handleSetActiveTab, chargers }) => {
   return (
     <Tabs defaultValue={activeTab} onValueChange={handleSetActiveTab}>
       <TabsList className='flex h-9 w-full justify-start overflow-x-auto overflow-y-hidden rounded-none bg-white03 p-0 px-5 no-scrollbar'>
-        {DUMMY_MEMBERS.map(member => (
-          <Tab key={member.value} name={member.name} value={member.name} />
+        {chargers?.map(charger => (
+          <Tab key={charger.name} name={charger.name} value={charger.name} />
         ))}
       </TabsList>
     </Tabs>

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -182,12 +182,17 @@ interface HomePageProps {}
 const HomePage: React.FC<HomePageProps> = () => {
   const [activeTab, setActiveTab] = useState<string>('전체');
 
+  const chargers = [
+    { name: '전체' },
+    ...Array.from(new Set(data.map(item => item.charger))).map(charger => ({ name: charger })),
+  ];
+
   return (
     <div>
       <HomeHeaderContainer />
       <div className='bg-white sticky top-0 z-10'>
         <WeeklyDateContainer />
-        <TabContainer activeTab={activeTab} handleSetActiveTab={setActiveTab} />
+        <TabContainer activeTab={activeTab} handleSetActiveTab={setActiveTab} chargers={chargers} />
       </div>
       <ListContainer
         items={data.filter(item => item.charger === activeTab || activeTab === '전체')}


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약

> 집안일 추가 - 집안일 할당 바텀 시트

## 📌 이슈 넘버

> #93

## 📝 작업 내용
- HomePage props 처리
- tab 컴포넌트 border 처리
- TabContainer props 처리
- HouseWorkSheetContainer에 사용자 정의, 프리셋 탭 추

## 📸 스크린샷(선택)
![image](https://github.com/user-attachments/assets/3a7629f3-396c-42cb-bbd9-b5dc3e7efbe3)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
