### PR TITLE
Feature/#91-날짜선택 바텀시트 컨테이너 추가

### DIFF
--- a/src/components/bottomSheet/DueDateSheetContainer/DueDateSheetContainer.stories.ts
+++ b/src/components/bottomSheet/DueDateSheetContainer/DueDateSheetContainer.stories.ts
@@ -1,0 +1,16 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import DueDateSheetContainer from '@/components/bottomSheet/DueDateSheetContainer/DueDateSheetContainer';
+
+const meta = {
+  title: 'components/bottomSheet/DueDateSheetContainer',
+  component: DueDateSheetContainer,
+  tags: ['autodocs'],
+} satisfies Meta<typeof DueDateSheetContainer>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {},
+};

--- a/src/components/bottomSheet/DueDateSheetContainer/DueDateSheetContainer.tsx
+++ b/src/components/bottomSheet/DueDateSheetContainer/DueDateSheetContainer.tsx
@@ -1,0 +1,31 @@
+import { useState } from 'react';
+import BottomSheetContainer from '@/components/common/BottomSheetContainer/BottomSheetContainer';
+import Button from '@/components/common/ButtonContainer/Button/Button';
+import { Calendar } from '@/components/common/Calendar/Calendar';
+
+const DueDateSheetContainer = () => {
+  const [isOpen, setOpen] = useState(true);
+  const [dueDate, setDueDate] = useState<Date | null>(null);
+
+  const handleDateChange = (date: Date) => {
+    setDueDate(date);
+  };
+  const handleCompleteClick = () => {
+    setOpen(false);
+  };
+
+  return (
+    <BottomSheetContainer isOpen={isOpen} setOpen={setOpen} title='날짜 선택'>
+      <div className='mt-4 flex min-h-96 flex-col gap-y-6 pb-6'>
+        <section aria-label='집안일 할당 바텀 시트' className='flex flex-1 flex-col gap-6'>
+          <Calendar />
+        </section>
+        <div className='px-5'>
+          <Button label='완료' variant='full' size='large' handleClick={handleCompleteClick} />
+        </div>
+      </div>
+    </BottomSheetContainer>
+  );
+};
+
+export default DueDateSheetContainer;

--- a/src/components/common/Calendar/Calendar.tsx
+++ b/src/components/common/Calendar/Calendar.tsx
@@ -13,7 +13,7 @@ function Calendar({ className, classNames, showOutsideDays = true, ...props }: C
       showOutsideDays={showOutsideDays}
       className={cn('p-3', className)}
       classNames={{
-        months: 'flex flex-col sm:flex-row space-y-4 sm:space-x-4 sm:space-y-0',
+        months: 'flex flex-col space-y-4 sm:space-x-4 sm:space-y-0',
         month: 'space-y-4',
         caption: 'flex justify-center pt-1 relative items-center',
         caption_label: 'text-sm font-medium',
@@ -22,8 +22,8 @@ function Calendar({ className, classNames, showOutsideDays = true, ...props }: C
           buttonVariants({ variant: 'outline' }),
           'h-7 w-7 bg-transparent p-0 opacity-50 hover:opacity-100'
         ),
-        nav_button_previous: 'absolute left-1',
-        nav_button_next: 'absolute right-1',
+        nav_button_previous: 'absolute left-1 mb-0',
+        nav_button_next: 'absolute right-1 mb-0',
         table: 'w-full border-collapse space-y-1',
         head_row: 'flex',
         head_cell: 'text-muted-foreground rounded-md w-8 font-normal text-[0.8rem] w-full',
@@ -36,7 +36,7 @@ function Calendar({ className, classNames, showOutsideDays = true, ...props }: C
         ),
         day: cn(
           buttonVariants({ variant: 'ghost' }),
-          'h-8 w-full p-0 font-normal aria-selected:opacity-100'
+          'h-8 w-full p-0 font-normal aria-selected:opacity-100 mb-0'
         ),
         day_range_start: 'day-range-start',
         day_range_end: 'day-range-end',


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약

> 날짜선택 바텀시트 컨테이너 추가

## 📌 이슈 넘버

> #91

## 📝 작업 내용
- 날짜선택 바텀시트 컨테이너 추가
- 스토리북 문서 추가
- 공통 캘린더 컴포넌트 스타일 수정

## 📸 스크린샷(선택)
![image](https://github.com/user-attachments/assets/17cde880-fa2b-4050-ba6b-1c134dee94e7)


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
