### PR TITLE
Feature/#104-fix-BottomSheet

### DIFF
--- a/src/components/HomeHeaderContainer/GroupSelectBtn/GroupSelectBtn.stories.ts
+++ b/src/components/HomeHeaderContainer/GroupSelectBtn/GroupSelectBtn.stories.ts
@@ -1,3 +1,4 @@
+import { action } from '@storybook/addon-actions';
 import type { Meta, StoryObj } from '@storybook/react';
 import GroupSelectBtn from './GroupSelectBtn';
 
@@ -5,6 +6,15 @@ const meta = {
   title: 'components/HomeHeaderContainer/GroupSelectBtn',
   component: GroupSelectBtn,
   tags: ['autodocs'],
+  argTypes: {
+    groupName: {
+      description: '그룹 이름',
+      control: 'text',
+    },
+    handleSetOpen: {
+      description: '바텀시트 열기 위한 set 함수',
+    },
+  },
 } satisfies Meta<typeof GroupSelectBtn>;
 
 export default meta;
@@ -13,5 +23,6 @@ type Story = StoryObj<typeof meta>;
 export const Default: Story = {
   args: {
     groupName: '우리집',
+    handleSetOpen: action('i clicked'),
   },
 };

--- a/src/components/HomeHeaderContainer/GroupSelectBtn/GroupSelectBtn.tsx
+++ b/src/components/HomeHeaderContainer/GroupSelectBtn/GroupSelectBtn.tsx
@@ -1,31 +1,25 @@
-import BottomSheetContainer from '@/components/common/BottomSheetContainer/BottomSheetContainer';
-import GroupOptionContainer from '@/components/GroupOptionContainer/GroupOptionContainer';
-import React, { useState } from 'react';
+import React from 'react';
 
 interface GroupSelectBtnProps {
   /** 현재 속해있는 그룹명 */
   groupName: string;
+  /**시트 열기 위한 함수 */
+  handleSetOpen: (value: boolean) => void;
 }
 
-const GroupSelectBtn: React.FC<GroupSelectBtnProps> = ({ groupName }: GroupSelectBtnProps) => {
-  const [isOpen, setOpen] = useState(false);
-
-  const handleClick = () => {
-    setOpen(true);
-  };
+const GroupSelectBtn: React.FC<GroupSelectBtnProps> = ({
+  groupName,
+  handleSetOpen,
+}: GroupSelectBtnProps) => {
   return (
     <>
       <button
-        className='text-12 flex items-center rounded-full bg-gray03 px-2 py-1 text-white03'
-        onClick={handleClick}
+        className='flex items-center rounded-full bg-gray03 px-2 py-1 text-12 text-white03'
+        onClick={() => handleSetOpen(true)}
       >
         <div className='h-4 w-4 rounded-full bg-gray01'></div>
         <div className='pl-2'>{groupName}</div>
       </button>
-
-      <BottomSheetContainer isOpen={isOpen} setOpen={setOpen} title='그룹 변경'>
-        <GroupOptionContainer />
-      </BottomSheetContainer>
     </>
   );
 };

--- a/src/components/HomeHeaderContainer/HomeHeaderContainer.stories.ts
+++ b/src/components/HomeHeaderContainer/HomeHeaderContainer.stories.ts
@@ -1,12 +1,24 @@
+import { action } from '@storybook/addon-actions';
 import type { Meta, StoryObj } from '@storybook/react';
 import HomeHeaderContainer from './HomeHeaderContainer';
 
 const meta = {
   title: 'components/HomeHeaderContainer',
   component: HomeHeaderContainer,
+  tags: ['autodocs'],
+  argTypes: {
+    handleSetOpen: {
+      description: '바텀시트 열기 위한 set 함수',
+    },
+  },
 } satisfies Meta<typeof HomeHeaderContainer>;
 
 export default meta;
+
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {};
+export const Default: Story = {
+  args: {
+    handleSetOpen: action('i clicked!'),
+  },
+};

--- a/src/components/HomeHeaderContainer/HomeHeaderContainer.tsx
+++ b/src/components/HomeHeaderContainer/HomeHeaderContainer.tsx
@@ -1,11 +1,18 @@
 import GroupSelectBtn from './GroupSelectBtn/GroupSelectBtn';
 import TitleDate from './TitleDate/TitleDate';
 
-const HomeHeaderContainer = () => {
+import React from 'react';
+
+interface HomeHeaderContainerProps {
+  /**시트 열기 위한 함수 */
+  handleSetOpen: (value: boolean) => void;
+}
+
+const HomeHeaderContainer: React.FC<HomeHeaderContainerProps> = ({ handleSetOpen }) => {
   return (
-    <div className='bg-white02 flex items-center justify-between p-5'>
+    <div className='flex items-center justify-between bg-white02 p-5'>
       <TitleDate dateText='2024년 11월 둘째 주' />
-      <GroupSelectBtn groupName='우리집' />
+      <GroupSelectBtn groupName='우리집' handleSetOpen={handleSetOpen} />
     </div>
   );
 };

--- a/src/components/bottomSheet/GroupSelectSheetContainer/GroupSelectSheetContainer.stories.tsx
+++ b/src/components/bottomSheet/GroupSelectSheetContainer/GroupSelectSheetContainer.stories.tsx
@@ -1,0 +1,41 @@
+import GroupSelectSheetContainer from '@/components/bottomSheet/GroupSelectSheetContainer/GroupSelectSheetContainer';
+import BottomSheetContainer from '@/components/common/BottomSheetContainer/BottomSheetContainer';
+import GroupOptionContainer from '@/components/GroupOptionContainer/GroupOptionContainer';
+import type { Meta, StoryObj } from '@storybook/react';
+import { useState } from 'react';
+
+const meta = {
+  title: 'components/common/bottomSheet/GroupSelectSheetContainer',
+  component: GroupSelectSheetContainer,
+  tags: ['autodocs'],
+  argTypes: {
+    isOpen: {
+      description: '시트 오픈 여부',
+      control: 'boolean',
+    },
+    handleSetOpen: {
+      description: '바텀시트 열고 닫는 함수',
+    },
+  },
+} satisfies Meta<typeof GroupSelectSheetContainer>;
+
+export default meta;
+
+const BottomSheetWithGroupOption = () => {
+  const [isOpen, setOpen] = useState(false);
+
+  return (
+    <>
+      <button onClick={() => setOpen(true)}>Open Bottom Sheet</button>
+      <BottomSheetContainer isOpen={isOpen} setOpen={setOpen} title='바텀시트 제목'>
+        <GroupOptionContainer />
+      </BottomSheetContainer>
+    </>
+  );
+};
+
+type Story = StoryObj<typeof GroupSelectSheetContainer>;
+
+export const Default: Story = {
+  render: () => <BottomSheetWithGroupOption />,
+};

--- a/src/components/bottomSheet/GroupSelectSheetContainer/GroupSelectSheetContainer.tsx
+++ b/src/components/bottomSheet/GroupSelectSheetContainer/GroupSelectSheetContainer.tsx
@@ -1,0 +1,21 @@
+import BottomSheetContainer from '@/components/common/BottomSheetContainer/BottomSheetContainer';
+import GroupOptionContainer from '@/components/GroupOptionContainer/GroupOptionContainer';
+import React from 'react';
+
+interface GroupSelectSheetContainerProps {
+  isOpen: boolean;
+  handleSetOpen: (value: boolean) => void;
+}
+
+const GroupSelectSheetContainer: React.FC<GroupSelectSheetContainerProps> = ({
+  isOpen,
+  handleSetOpen,
+}) => {
+  return (
+    <BottomSheetContainer isOpen={isOpen} setOpen={handleSetOpen} title='그룹 변경'>
+      <GroupOptionContainer />
+    </BottomSheetContainer>
+  );
+};
+
+export default GroupSelectSheetContainer;

--- a/src/components/bottomSheet/ManagerSelectSheetContainer/ManagerSelectSheetContainer.tsx
+++ b/src/components/bottomSheet/ManagerSelectSheetContainer/ManagerSelectSheetContainer.tsx
@@ -1,0 +1,41 @@
+import BottomSheetContainer from '@/components/common/BottomSheetContainer/BottomSheetContainer';
+import Button from '@/components/common/ButtonContainer/Button/Button';
+import ManagerSelectContainer from '@/components/ManagerSelectContainer/ManagerSelectContainer';
+import React from 'react';
+import { Dispatch, SetStateAction } from 'react';
+
+interface ManagerSelectSheetContainerProps {
+  /**바텀시트 오픈 여부 */
+  isOpen: boolean;
+  /**isOpen 바꾸는 set함수 */
+  setIsOpen: Dispatch<SetStateAction<boolean>>;
+  /**선택된 담당자 */
+  selectedMember: string;
+  /**담당자 바꾸는 set함수 */
+  handleSetSelectMember: Dispatch<SetStateAction<string>>;
+  /**선택 완료 후 처리하는 함수 */
+  handleDoneClick: () => void;
+}
+
+const ManagerSelectSheetContainer: React.FC<ManagerSelectSheetContainerProps> = ({
+  isOpen,
+  setIsOpen,
+  selectedMember,
+  handleSetSelectMember,
+  handleDoneClick,
+}) => {
+  return (
+    <BottomSheetContainer isOpen={isOpen} setOpen={setIsOpen} title='담당자 고르기'>
+      <div className='flex flex-col gap-y-6 px-5 pb-6'>
+        <ManagerSelectContainer
+          selectedMember={selectedMember}
+          handleSelectMember={handleSetSelectMember}
+        />
+        <Button label='완료' variant='full' size='large' handleClick={handleDoneClick} />
+        <button className='text-14 underline'>AI가 딱 맞는 사람을 선택할게요</button>
+      </div>
+    </BottomSheetContainer>
+  );
+};
+
+export default ManagerSelectSheetContainer;

--- a/src/components/bottomSheet/ManagerSelectSheetContainer/ManagerSelectSheetContainter.stories.tsx
+++ b/src/components/bottomSheet/ManagerSelectSheetContainer/ManagerSelectSheetContainter.stories.tsx
@@ -1,0 +1,64 @@
+import BottomSheetContainer from '@/components/common/BottomSheetContainer/BottomSheetContainer';
+import ManagerSelectSheetContainer from '@/components/bottomSheet/ManagerSelectSheetContainer/ManagerSelectSheetContainer';
+import type { Meta, StoryObj } from '@storybook/react';
+import { useState } from 'react';
+import Button from '@/components/common/ButtonContainer/Button/Button';
+import ManagerSelectContainer from '@/components/ManagerSelectContainer/ManagerSelectContainer';
+
+const meta = {
+  title: 'components/common/bottomSheet/ManagerSelectSheetContainer',
+  component: ManagerSelectSheetContainer,
+  tags: ['autodocs'],
+  argTypes: {
+    isOpen: {
+      description: '시트 오픈 여부',
+      control: 'boolean',
+    },
+    setIsOpen: {
+      description: '바텀시트 여는 set함수',
+    },
+    selectedMember: {
+      description: '선택된 멤버',
+      control: 'text',
+    },
+    handleSetSelectMember: {
+      description: '담당자 선택하는 set 함수',
+    },
+    handleDoneClick: {
+      description: '선택 후 처리하는 함수',
+    },
+  },
+} satisfies Meta<typeof ManagerSelectSheetContainer>;
+
+export default meta;
+
+const BottomSheetWithManager = () => {
+  const [isOpen, setOpen] = useState(false);
+  const [selectedMember, setSelectedMember] = useState('');
+
+  const handleDoneClick = () => {
+    setOpen(false);
+  };
+
+  return (
+    <>
+      <button onClick={() => setOpen(true)}>Open Bottom Sheet</button>
+      <BottomSheetContainer isOpen={isOpen} setOpen={setOpen} title='바텀시트 제목'>
+        <div className='flex flex-col gap-y-6 px-5 pb-6'>
+          <ManagerSelectContainer
+            selectedMember={selectedMember}
+            handleSelectMember={setSelectedMember}
+          />
+          <Button label='완료' variant='full' size='large' handleClick={handleDoneClick} />
+          <button className='text-14 underline'>AI가 딱 맞는 사람을 선택할게요</button>
+        </div>
+      </BottomSheetContainer>
+    </>
+  );
+};
+
+type Story = StoryObj<typeof ManagerSelectSheetContainer>;
+
+export const Default: Story = {
+  render: () => <BottomSheetWithManager />,
+};

--- a/src/index.css
+++ b/src/index.css
@@ -62,10 +62,18 @@
   }
 }
 
-.react-modal-sheet-container {
-  /* margin: 0 auto !important;
+body:has(.react-modal-sheet-container) {
+  overflow: hidden !important;
+  pointer-events: none;
+}
+
+.react-modal-sheet-backdrop {
   max-width: 430px !important;
-  width: 100% !important; */
+  left: 50% !important;
+  transform: translateX(-50%) !important;
+}
+
+.react-modal-sheet-container {
   border-top-left-radius: 1rem !important;
   border-top-right-radius: 1rem !important;
   box-shadow: none !important;

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -3,6 +3,7 @@ import HomeHeaderContainer from '@/components/HomeHeaderContainer/HomeHeaderCont
 import WeeklyDateContainer from '@/components/WeeklyDateContainer/WeeklyDateContainer';
 import TabContainer from '@/components/common/TabContainer/TabContainer';
 import ListContainer from '@/components/ListContainer/ListContainer';
+import GroupSelectSheetContainer from '@/components/bottomSheet/GroupSelectSheetContainer/GroupSelectSheetContainer';
 
 export const data = [
   {
@@ -181,10 +182,11 @@ interface HomePageProps {}
 
 const HomePage: React.FC<HomePageProps> = () => {
   const [activeTab, setActiveTab] = useState<string>('전체');
+  const [isOpen, setIsOpen] = useState(false);
 
   return (
     <div>
-      <HomeHeaderContainer />
+      <HomeHeaderContainer handleSetOpen={setIsOpen} />
       <div className='bg-white sticky top-0 z-10'>
         <WeeklyDateContainer />
         <TabContainer activeTab={activeTab} handleSetActiveTab={setActiveTab} />
@@ -192,6 +194,7 @@ const HomePage: React.FC<HomePageProps> = () => {
       <ListContainer
         items={data.filter(item => item.charger === activeTab || activeTab === '전체')}
       />
+      <GroupSelectSheetContainer isOpen={isOpen} handleSetOpen={setIsOpen} />
     </div>
   );
 };

--- a/src/pages/HouseWorkStepTwoPage.tsx
+++ b/src/pages/HouseWorkStepTwoPage.tsx
@@ -1,8 +1,7 @@
-import BottomSheetContainer from '@/components/common/BottomSheetContainer/BottomSheetContainer';
+import ManagerSelectSheetContainer from '@/components/bottomSheet/ManagerSelectSheetContainer/ManagerSelectSheetContainer';
 import Button from '@/components/common/ButtonContainer/Button/Button';
 import SelectBtn from '@/components/common/SelectBtn/SelectBtn';
 import SelectedBtn from '@/components/common/SelectedBtn/SelectedBtn';
-import MaganerSelectContainer from '@/components/ManagerSelectContainer/ManagerSelectContainer';
 import PageHeaderContainer from '@/components/PageHeaderContainer/PageHeaderContainer';
 import TimeContainer from '@/components/TimeContainer/TimeContainer';
 import { useState } from 'react';
@@ -18,7 +17,7 @@ const HouseWorkStepTwoPage = () => {
   const navigate = useNavigate();
   const [manager, setManager] = useState<string | null>(null);
   const [selectedMember, setSelectedMember] = useState('');
-  const [isOpen, setOpen] = useState(false);
+  const [isOpen, setIsOpen] = useState(false);
   const [time, setTime] = useState<SelectedTime | null>(null);
 
   const handleBackClick = () => {
@@ -30,11 +29,11 @@ const HouseWorkStepTwoPage = () => {
   };
 
   const handleManagerClick = () => {
-    setOpen(true);
+    setIsOpen(true);
   };
 
   const handleDoneClick = () => {
-    setOpen(false);
+    setIsOpen(false);
     setManager(selectedMember);
   };
 
@@ -61,16 +60,13 @@ const HouseWorkStepTwoPage = () => {
         <Button label='다음' variant='full' size='large' handleClick={handleNextClick} />
       </div>
 
-      <BottomSheetContainer isOpen={isOpen} setOpen={setOpen} title='담당자 고르기'>
-        <div className='flex flex-col gap-y-6 px-5 pb-6'>
-          <MaganerSelectContainer
-            selectedMember={selectedMember}
-            handleSelectMember={setSelectedMember}
-          />
-          <Button label='완료' variant='full' size='large' handleClick={handleDoneClick} />
-          <button className='text-14 underline'>AI가 딱 맞는 사람을 선택할게요</button>
-        </div>
-      </BottomSheetContainer>
+      <ManagerSelectSheetContainer
+        isOpen={isOpen}
+        setIsOpen={setIsOpen}
+        selectedMember={selectedMember}
+        handleSetSelectMember={setSelectedMember}
+        handleDoneClick={handleDoneClick}
+      />
     </>
   );
 };


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약

> ex) 메인페이지 - 라우트 연결

바텀시트 다 컨테이너로 빼는 작업을 했습니다.
그리고 홈에서 페이지가 밀리는 오류가 있었는데 이것도 해결했습니다.

## 📌 이슈 넘버

> ex) #이슈번호, #이슈번호

#104 

## 📝 작업 내용

## 📸 스크린샷(선택)

![image](https://github.com/user-attachments/assets/827e0c22-428c-4101-977d-c02c4cf0582b)


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
