### PR TITLE
Feature/#124 그룹원 관리 컨테이너 추가

### DIFF
--- a/src/components/common/GroupMemberManageContainer/GroupMemberManageContainer.stories.tsx
+++ b/src/components/common/GroupMemberManageContainer/GroupMemberManageContainer.stories.tsx
@@ -1,0 +1,58 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import GroupMemberManageContainer from './GroupMemberManageContainer';
+
+const meta: Meta<typeof GroupMemberManageContainer> = {
+  title: 'Components/GroupMemberManageContainer',
+  component: GroupMemberManageContainer,
+  tags: ['autodocs'],
+  argTypes: {
+    leader: { control: 'boolean' },
+    members: { control: 'object' },
+    currentUser: { control: 'text' },
+    handleClick: { action: 'clicked' },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof GroupMemberManageContainer>;
+
+export const LeaderView: Story = {
+  args: {
+    leader: true,
+    members: ['민재', '서준', '지우'],
+    currentUser: '민재',
+  },
+};
+
+export const MemberView: Story = {
+  args: {
+    leader: false,
+    members: ['민재', '서준', '지우'],
+    currentUser: '민재',
+  },
+};
+
+export const SingleMember: Story = {
+  args: {
+    leader: false,
+    members: ['민재'],
+    currentUser: '민재',
+  },
+};
+
+export const ManyMembers: Story = {
+  args: {
+    leader: true,
+    members: ['민재', '서준', '지우', '현우', '도윤', '주원'],
+    currentUser: '민재',
+  },
+};
+
+export const EmptyMembers: Story = {
+  args: {
+    leader: false,
+    members: [],
+    currentUser: '민재',
+  },
+};

--- a/src/components/common/GroupMemberManageContainer/GroupMemberManageContainer.tsx
+++ b/src/components/common/GroupMemberManageContainer/GroupMemberManageContainer.tsx
@@ -1,0 +1,35 @@
+import GroupMemberManage from '@/components/common/GroupMemberManageContainer/GroupMemberManage/GroupMemberManage';
+import React from 'react';
+
+interface GroupMemberManageContainerProps {
+  leader: boolean;
+  members: string[];
+  currentUser: string;
+  handleClick?: (member: string) => void;
+}
+
+const GroupMemberManageContainer: React.FC<GroupMemberManageContainerProps> = ({
+  leader,
+  members,
+  currentUser,
+  handleClick,
+}) => {
+  return (
+    <div className='flex flex-col gap-2'>
+      <p className='text-14'>그룹원 관리</p>
+      <div className='flex flex-col gap-2'>
+        {members.map((member, index) => (
+          <GroupMemberManage
+            key={index}
+            leader={leader}
+            member={member}
+            isCurrentUser={member === currentUser}
+            handleClick={() => handleClick?.(member)}
+          />
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default GroupMemberManageContainer;


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약

> 그룹 설정 페이지 - 그룹원 관리 컨테이너

## 📌 이슈 넘버

> #124

## 📝 작업 내용
- 그룹원 관리 컨테이너 추가 

## 📸 스크린샷(선택)
![image](https://github.com/user-attachments/assets/0f905de8-e2bb-4460-ac99-43437954bd4e)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
