### PR TITLE
Feature/#108-주간 완료율 컨테이너 추가

### DIFF
--- a/src/components/WeeklyCompletionContainer/CompletionBarGraph/CompletionBarGraph.stories.tsx
+++ b/src/components/WeeklyCompletionContainer/CompletionBarGraph/CompletionBarGraph.stories.tsx
@@ -1,0 +1,16 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import CompletionBarGraph from '@/components/WeeklyCompletionContainer/CompletionBarGraph/CompletionBarGraph';
+
+const meta = {
+  title: 'components/WeeklyCompletionContainer/CompletionBarGraph',
+  component: CompletionBarGraph,
+  tags: ['autodocs'],
+} satisfies Meta<typeof CompletionBarGraph>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: { completed: 2, notCompleted: 2 },
+};

--- a/src/components/WeeklyCompletionContainer/CompletionBarGraph/CompletionBarGraph.tsx
+++ b/src/components/WeeklyCompletionContainer/CompletionBarGraph/CompletionBarGraph.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { Progress } from '@/components/ui/progress';
+
+interface CompletionBarGraphProps {
+  completed: number;
+  notCompleted: number;
+}
+
+const CompletionBarGraph: React.FC<CompletionBarGraphProps> = ({ completed, notCompleted }) => {
+  const total = completed + notCompleted;
+  const completionRate = total > 0 ? (completed / total) * 100 : 0; // 완료율 계산
+
+  return (
+    <div>
+      <Progress value={completionRate} className='h-5' />
+    </div>
+  );
+};
+
+export default CompletionBarGraph;

--- a/src/components/WeeklyCompletionContainer/CompletionText/CompletionText.stories.tsx
+++ b/src/components/WeeklyCompletionContainer/CompletionText/CompletionText.stories.tsx
@@ -1,0 +1,26 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import CompletionText from '@/components/WeeklyCompletionContainer/CompletionText/CompletionText';
+
+const meta = {
+  title: 'components/WeeklyCompletionContainer/CompletionText',
+  component: CompletionText,
+  tags: ['autodocs'],
+} satisfies Meta<typeof CompletionText>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    completedText: '완료',
+    num: 2,
+  },
+};
+
+export const NotCompleted: Story = {
+  args: {
+    completedText: '미완료',
+    num: 2,
+  },
+};

--- a/src/components/WeeklyCompletionContainer/CompletionText/CompletionText.tsx
+++ b/src/components/WeeklyCompletionContainer/CompletionText/CompletionText.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+
+interface CompletionTextProps {
+  completedText: string;
+  num: number;
+}
+
+const CompletionText: React.FC<CompletionTextProps> = ({ completedText, num }) => {
+  return (
+    <div className='flex items-center justify-between'>
+      <p className='text-gray01'>{completedText}</p>
+      <p className='text-18 text-black02'>
+        <strong>{num}</strong>개
+      </p>
+    </div>
+  );
+};
+
+export default CompletionText;

--- a/src/components/WeeklyCompletionContainer/WeeklyCompletionContainer.stories.tsx
+++ b/src/components/WeeklyCompletionContainer/WeeklyCompletionContainer.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react';
 import WeeklyCompletionContainer from '@/components/WeeklyCompletionContainer/WeeklyCompletionContainer';
 
 const meta = {
-  title: 'components/WeeklyCompletionContainer/WeeklyCompletionContainer',
+  title: 'components/WeeklyCompletionContainer',
   component: WeeklyCompletionContainer,
   tags: ['autodocs'],
 } satisfies Meta<typeof WeeklyCompletionContainer>;

--- a/src/components/WeeklyCompletionContainer/WeeklyCompletionContainer.stories.tsx
+++ b/src/components/WeeklyCompletionContainer/WeeklyCompletionContainer.stories.tsx
@@ -1,0 +1,20 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import WeeklyCompletionContainer from '@/components/WeeklyCompletionContainer/WeeklyCompletionContainer';
+
+const meta = {
+  title: 'components/WeeklyCompletionContainer/WeeklyCompletionContainer',
+  component: WeeklyCompletionContainer,
+  tags: ['autodocs'],
+} satisfies Meta<typeof WeeklyCompletionContainer>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    groupName: '우리집',
+    completed: 2,
+    notCompleted: 2,
+  },
+};

--- a/src/components/WeeklyCompletionContainer/WeeklyCompletionContainer.tsx
+++ b/src/components/WeeklyCompletionContainer/WeeklyCompletionContainer.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import TextTag from '@/components/common/TextTag/TextTag';
+import CompletionText from '@/components/WeeklyCompletionContainer/CompletionText/CompletionText';
+
+interface WeeklyCompletionContainerProps {
+  /** 그룹명 */
+  groupName: string;
+  // status: string; // 추후 상태에 따라 아이콘 변경
+  /** 완료된 집안일 개수 */
+  completed: number;
+  /** 미완료된 집안일 개수 */
+  notCompleted: number;
+}
+
+const WeeklyCompletionContainer: React.FC<WeeklyCompletionContainerProps> = ({
+  groupName,
+  completed,
+  notCompleted,
+}) => {
+  return (
+    <div>
+      <div className='flex items-center justify-center gap-2'>
+        <TextTag type='grayfill' label={groupName} />
+        <p>주간 리스트</p>
+      </div>
+      <div className='flex w-full items-center justify-between gap-10 p-7'>
+        <div className='h-16 w-16 flex-1 border border-solid'></div>
+        <div className='flex-1'>
+          <CompletionText completedText='완료' num={completed} />
+          <CompletionText completedText='미완료' num={notCompleted} />
+        </div>
+      </div>
+      <div></div>
+    </div>
+  );
+};
+
+export default WeeklyCompletionContainer;

--- a/src/components/WeeklyCompletionContainer/WeeklyCompletionContainer.tsx
+++ b/src/components/WeeklyCompletionContainer/WeeklyCompletionContainer.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import TextTag from '@/components/common/TextTag/TextTag';
 import CompletionText from '@/components/WeeklyCompletionContainer/CompletionText/CompletionText';
+import CompletionBarGraph from '@/components/WeeklyCompletionContainer/CompletionBarGraph/CompletionBarGraph';
 
 interface WeeklyCompletionContainerProps {
   /** 그룹명 */
@@ -30,7 +31,9 @@ const WeeklyCompletionContainer: React.FC<WeeklyCompletionContainerProps> = ({
           <CompletionText completedText='미완료' num={notCompleted} />
         </div>
       </div>
-      <div></div>
+      <div>
+        <CompletionBarGraph completed={completed} notCompleted={notCompleted} />
+      </div>
     </div>
   );
 };

--- a/src/components/ui/progress.tsx
+++ b/src/components/ui/progress.tsx
@@ -1,9 +1,9 @@
-"use client"
+'use client';
 
-import * as React from "react"
-import * as ProgressPrimitive from "@radix-ui/react-progress"
+import * as React from 'react';
+import * as ProgressPrimitive from '@radix-ui/react-progress';
 
-import { cn } from "@/lib/utils"
+import { cn } from '@/lib/utils';
 
 const Progress = React.forwardRef<
   React.ElementRef<typeof ProgressPrimitive.Root>,
@@ -11,18 +11,15 @@ const Progress = React.forwardRef<
 >(({ className, value, ...props }, ref) => (
   <ProgressPrimitive.Root
     ref={ref}
-    className={cn(
-      "relative h-2 w-full overflow-hidden rounded-full bg-primary/20",
-      className
-    )}
+    className={cn('relative h-2 w-full overflow-hidden rounded-full bg-primary/20', className)}
     {...props}
   >
     <ProgressPrimitive.Indicator
-      className="h-full w-full flex-1 bg-primary transition-all"
+      className='h-full w-full flex-1 rounded-full bg-primary transition-all'
       style={{ transform: `translateX(-${100 - (value || 0)}%)` }}
     />
   </ProgressPrimitive.Root>
-))
-Progress.displayName = ProgressPrimitive.Root.displayName
+));
+Progress.displayName = ProgressPrimitive.Root.displayName;
 
-export { Progress }
+export { Progress };


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약

> 통계페이지 - 주간 완료율 컨테이너 추가

## 📌 이슈 넘버

> #108 

## 📝 추가할 작업 내용
- 그룹명은 추후 스타일 추가
- 아이콘은 추후 디자인 추가


## 📸 스크린샷(선택)
![image](https://github.com/user-attachments/assets/c08f525c-d5e0-49d1-b1a8-d95b37473f02)


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
