### PR TITLE
Feature/#126 초대 링크 컨테이너 추가 

### DIFF
--- a/src/components/InviteLinkContainer/InviteLink/InviteLink.tsx
+++ b/src/components/InviteLinkContainer/InviteLink/InviteLink.tsx
@@ -5,7 +5,7 @@ const InviteLink = () => {
 
   const handleGenerateLink = () => {
     // TODO: 나중에 API 호출로 바꾸기
-    setInviteLink('https://contents.ohou....');
+    setInviteLink('https://contents.ohou.contents.ohoucontents.ohou...');
   };
 
   const handleCopyLink = () => {
@@ -16,11 +16,13 @@ const InviteLink = () => {
   };
 
   return (
-    <div className='flex h-9 items-center justify-between rounded-full border border-gray02 px-2 py-1 text-16'>
+    <div className='flex h-9 items-center justify-between rounded-full border border-gray02 px-4 py-1 text-16'>
       {inviteLink ? (
         <>
-          <p className='flex-1 truncate px-2'>{inviteLink}</p>
-          <button className='text-14 text-gray01' onClick={handleCopyLink}>
+          <div className='min-w-0 flex-1 overflow-hidden'>
+            <p className='truncate'>{inviteLink}</p>
+          </div>
+          <button className='shrink-0 pl-4 text-14 text-gray01' onClick={handleCopyLink}>
             링크복사
           </button>
         </>

--- a/src/components/InviteLinkContainer/InviteLinkContainer.stories.tsx
+++ b/src/components/InviteLinkContainer/InviteLinkContainer.stories.tsx
@@ -1,0 +1,14 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import InviteLinkContainer from './InviteLinkContainer';
+
+const meta: Meta<typeof InviteLinkContainer> = {
+  title: 'Components/InviteLinkContainer',
+  component: InviteLinkContainer,
+  tags: ['autodocs'],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof InviteLinkContainer>;
+
+export const Default: Story = {};

--- a/src/components/InviteLinkContainer/InviteLinkContainer.tsx
+++ b/src/components/InviteLinkContainer/InviteLinkContainer.tsx
@@ -1,0 +1,12 @@
+import InviteLink from '@/components/InviteLinkContainer/InviteLink/InviteLink';
+
+const InviteLinkContainer = () => {
+  return (
+    <div className='flex flex-col gap-2'>
+      <p className='text-14'>초대 링크</p>
+      <InviteLink />
+    </div>
+  );
+};
+
+export default InviteLinkContainer;


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약

> 그룹 설정 페이지 - 초대 링크 컨테이너

## 📌 이슈 넘버

> #126

## 📝 작업 내용
- 초대 링크 컨테이너
- 링크 넘어가는 부분 overflow-hidden

## 📸 스크린샷(선택)
![image](https://github.com/user-attachments/assets/fbc5bc6d-b141-4183-9949-7a6ecf864e09)
![image](https://github.com/user-attachments/assets/a935e6da-a980-493c-8e19-c1b05c086750)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
