### PR TITLE
Feature/#94-집안일 추가 STEP1 바텀시트 연결

### DIFF
--- a/src/components/bottomSheet/DueDateSheetContainer/DueDateSheetContainer.stories.ts
+++ b/src/components/bottomSheet/DueDateSheetContainer/DueDateSheetContainer.stories.ts
@@ -1,8 +1,9 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import DueDateSheetContainer from '@/components/bottomSheet/DueDateSheetContainer/DueDateSheetContainer';
+import { action } from '@storybook/addon-actions';
 
 const meta = {
-  title: 'components/bottomSheet/DueDateSheetContainer',
+  title: 'components/common/bottomSheet/DueDateSheetContainer',
   component: DueDateSheetContainer,
   tags: ['autodocs'],
 } satisfies Meta<typeof DueDateSheetContainer>;
@@ -12,5 +13,8 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
-  args: {},
+  args: {
+    isOpen: true,
+    setOpen: action('setOpen'),
+  },
 };

--- a/src/components/bottomSheet/DueDateSheetContainer/DueDateSheetContainer.tsx
+++ b/src/components/bottomSheet/DueDateSheetContainer/DueDateSheetContainer.tsx
@@ -1,16 +1,16 @@
-import { useState } from 'react';
 import BottomSheetContainer from '@/components/common/BottomSheetContainer/BottomSheetContainer';
 import Button from '@/components/common/ButtonContainer/Button/Button';
 import { Calendar } from '@/components/common/Calendar/Calendar';
 
-const DueDateSheetContainer = () => {
-  const [isOpen, setOpen] = useState(true);
-  const [dueDate, setDueDate] = useState<Date | null>(null);
+interface DueDateSheetContainerProps {
+  /** 바텀시트 오픈 여부 */
+  isOpen: boolean;
+  /** isOpen 바꾸는 set함수 */
+  setOpen: (isOpen: boolean) => void;
+}
 
-  const handleDateChange = (date: Date) => {
-    setDueDate(date);
-  };
-  const handleCompleteClick = () => {
+const DueDateSheetContainer = ({ isOpen, setOpen }: DueDateSheetContainerProps) => {
+  const handleDoneClick = () => {
     setOpen(false);
   };
 
@@ -21,7 +21,7 @@ const DueDateSheetContainer = () => {
           <Calendar />
         </section>
         <div className='px-5'>
-          <Button label='완료' variant='full' size='large' handleClick={handleCompleteClick} />
+          <Button label='완료' variant='full' size='large' handleClick={handleDoneClick} />
         </div>
       </div>
     </BottomSheetContainer>

--- a/src/components/bottomSheet/HouseWorkSheetContainer/HouseWorkSheetContainer.stories.tsx
+++ b/src/components/bottomSheet/HouseWorkSheetContainer/HouseWorkSheetContainer.stories.tsx
@@ -1,5 +1,6 @@
 import HouseWorkSheetContainer from '@/components/bottomSheet/HouseWorkSheetContainer/HouseWorkSheetContainer';
 import type { Meta, StoryObj } from '@storybook/react';
+import { action } from '@storybook/addon-actions';
 
 const meta = {
   title: 'components/common/bottomSheet/HouseWorkSheetContainer',
@@ -12,5 +13,8 @@ export default meta;
 type Story = StoryObj<typeof HouseWorkSheetContainer>;
 
 export const Default: Story = {
-  args: {},
+  args: {
+    isOpen: true,
+    setOpen: action('setOpen'),
+  },
 };

--- a/src/components/bottomSheet/HouseWorkSheetContainer/HouseWorkSheetContainer.tsx
+++ b/src/components/bottomSheet/HouseWorkSheetContainer/HouseWorkSheetContainer.tsx
@@ -1,14 +1,17 @@
 import BottomSheetContainer from '@/components/common/BottomSheetContainer/BottomSheetContainer';
-import ButtonContainer from '@/components/common/ButtonContainer/ButtonContainer';
+import Button from '@/components/common/ButtonContainer/Button/Button';
 import TabContainer from '@/components/common/TabContainer/TabContainer';
 import PresetTabContainer from '@/components/PresetTabContainer/PresetTabContainer';
 import { useState } from 'react';
 
-interface HouseWorkSheetContainerProps {}
+interface HouseWorkSheetContainerProps {
+  /** 바텀시트 오픈 여부 */
+  isOpen: boolean;
+  /** isOpen 바꾸는 set함수 */
+  setOpen: (isOpen: boolean) => void;
+}
 
-const HouseWorkSheetContainer: React.FC<HouseWorkSheetContainerProps> = ({}) => {
-  const [isOpen, setOpen] = useState(true);
-
+const HouseWorkSheetContainer: React.FC<HouseWorkSheetContainerProps> = ({ isOpen, setOpen }) => {
   const mockData = {
     userData: [
       {
@@ -68,6 +71,9 @@ const HouseWorkSheetContainer: React.FC<HouseWorkSheetContainerProps> = ({}) => 
   const chargers = Object.keys(mockData).map(key => ({
     name: key === 'userData' ? '사용자 정의' : '프리셋',
   }));
+  const handleDoneClick = () => {
+    setOpen(false);
+  };
 
   return (
     <BottomSheetContainer isOpen={isOpen} setOpen={setOpen} title='집안일 선택'>
@@ -83,18 +89,7 @@ const HouseWorkSheetContainer: React.FC<HouseWorkSheetContainerProps> = ({}) => 
           />
         </section>
         <div className='px-5'>
-          <ButtonContainer
-            buttonLeft={{
-              label: '설정',
-              variant: 'outline',
-              size: 'small',
-            }}
-            buttonRight={{
-              label: '선택',
-              variant: 'full',
-              size: 'large',
-            }}
-          />
+          <Button label='선택 완료' variant='full' size='large' handleClick={handleDoneClick} />
         </div>
       </div>
     </BottomSheetContainer>

--- a/src/components/common/Calendar/Calendar.tsx
+++ b/src/components/common/Calendar/Calendar.tsx
@@ -20,10 +20,10 @@ function Calendar({ className, classNames, showOutsideDays = true, ...props }: C
         nav: 'space-x-1 flex items-center',
         nav_button: cn(
           buttonVariants({ variant: 'outline' }),
-          'h-7 w-7 bg-transparent p-0 opacity-50 hover:opacity-100'
+          'h-7 w-7 bg-transparent p-0 opacity-50 hover:opacity-100 mb-0'
         ),
-        nav_button_previous: 'absolute left-1 mb-0',
-        nav_button_next: 'absolute right-1 mb-0',
+        nav_button_previous: 'absolute left-1',
+        nav_button_next: 'absolute right-1',
         table: 'w-full border-collapse space-y-1',
         head_row: 'flex',
         head_cell: 'text-muted-foreground rounded-md w-8 font-normal text-[0.8rem] w-full',

--- a/src/pages/HouseWorkStepOnePage.tsx
+++ b/src/pages/HouseWorkStepOnePage.tsx
@@ -4,20 +4,24 @@ import Button from '@/components/common/ButtonContainer/Button/Button';
 import SelectBtn from '@/components/common/SelectBtn/SelectBtn';
 import SelectedBtn from '@/components/common/SelectedBtn/SelectedBtn';
 import PageHeaderContainer from '@/components/PageHeaderContainer/PageHeaderContainer';
+import DueDateSheetContainer from '@/components/bottomSheet/DueDateSheetContainer/DueDateSheetContainer';
+import HouseWorkSheetContainer from '@/components/bottomSheet/HouseWorkSheetContainer/HouseWorkSheetContainer';
 
 const HouseWorkStepOnePage = () => {
   const navigate = useNavigate();
   const [houseWork, setHouseWork] = useState(null);
-  const [dueDate, setDueDate] = useState(null);
+  const [dueDate, setDueDate] = useState<Date | null>(null);
+  const [isHouseWorkSheetOpen, setHouseWorkSheetOpen] = useState(false);
+  const [isDueDateSheetOpen, setDueDateSheetOpen] = useState(false);
 
   const handleBackClick = () => {
     navigate(-1);
   };
   const handleHouseWorkClick = () => {
-    console.log('bottom sheet open!');
+    setHouseWorkSheetOpen(true);
   };
   const handleDueDateClick = () => {
-    console.log('bottom sheet open!');
+    setDueDateSheetOpen(true);
   };
   const handleNextClick = () => {
     navigate('/add-housework/step2');
@@ -42,6 +46,9 @@ const HouseWorkStepOnePage = () => {
         )}
       </section>
       <Button variant='full' size='large' label='다음' handleClick={handleNextClick} />
+
+      <HouseWorkSheetContainer isOpen={isHouseWorkSheetOpen} setOpen={setHouseWorkSheetOpen} />
+      <DueDateSheetContainer isOpen={isDueDateSheetOpen} setOpen={setDueDateSheetOpen} />
     </div>
   );
 };


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약

> 집안일 추가 STEP1 바텀시트 연결

## 📌 이슈 넘버

> #94 

## 📝 작업 내용
- 집안일 추가 바텀시트 연결
- 캘린터 바텀시트 연결
- 네이밍 통일
- 스토리북 문서 수정

## 📸 스크린샷(선택)
![image](https://github.com/user-attachments/assets/e4e1467d-ba88-45cf-994b-b455810936ee)
![image](https://github.com/user-attachments/assets/eff3ed06-3fc1-44b4-8af2-6a2deaef946c)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
