### PR TITLE
Feature/#130 그룹 설정 페이지 추가

### DIFF
--- a/src/components/GroupMemberManagerContainer/GroupMemberManage/GroupMemberManage.tsx
+++ b/src/components/GroupMemberManagerContainer/GroupMemberManage/GroupMemberManage.tsx
@@ -15,10 +15,12 @@ const GroupMemberManage: React.FC<GroupMemberManageProps> = ({
 
   return (
     <div
-      className={`flex h-9 items-center justify-between rounded-full border border-gray02 px-2 py-1 text-16 ${!showButton ? 'bg-white02' : ''}`}
+      className={`flex h-12 items-center justify-between rounded-full border border-solid border-white01 px-2 py-1 text-16 shadow-sm ${!showButton ? 'bg-white02' : ''}`}
     >
       {member}
-      {showButton && <i className='h-4 w-4 border border-black02' onClick={handleClick}></i>}
+      {showButton && (
+        <i className='h-4 w-4 border border-solid border-black02' onClick={handleClick}></i>
+      )}
     </div>
   );
 };

--- a/src/components/InviteLinkContainer/InviteLink/InviteLink.tsx
+++ b/src/components/InviteLinkContainer/InviteLink/InviteLink.tsx
@@ -16,7 +16,7 @@ const InviteLink = () => {
   };
 
   return (
-    <div className='flex h-9 items-center justify-between rounded-full border border-gray02 px-4 py-1 text-16'>
+    <div className='flex h-12 items-center justify-between rounded-full border border-solid border-white01 px-4 py-1 text-16 shadow-sm'>
       {inviteLink ? (
         <>
           <div className='min-w-0 flex-1 overflow-hidden'>

--- a/src/components/common/ButtonContainer/Button/Button.tsx
+++ b/src/components/common/ButtonContainer/Button/Button.tsx
@@ -9,11 +9,13 @@ interface ButtonProps {
   size: 'small' | 'medium' | 'large';
   /** 클릭 이벤트 */
   handleClick?: () => void;
+  /** 커스텀 스타일 */
+  className?: string;
 }
 
-const Button = ({ label, variant = 'full', size, handleClick }: ButtonProps) => {
+const Button = ({ label, variant = 'full', size, handleClick, className }: ButtonProps) => {
   return (
-    <ButtonComponent variant={variant} size={size} onClick={handleClick}>
+    <ButtonComponent variant={variant} size={size} onClick={handleClick} className={className}>
       {label}
     </ButtonComponent>
   );

--- a/src/components/common/InputContainer/InputBox/InputBox.tsx
+++ b/src/components/common/InputContainer/InputBox/InputBox.tsx
@@ -12,7 +12,7 @@ const InputBox: React.FC<InputBoxProps> = ({ value, placeholder, disabled, handl
     <div>
       <Input
         placeholder={placeholder}
-        className='rounded-full text-16'
+        className='h-12 rounded-full text-16'
         disabled={disabled}
         value={value}
         onChange={e => handleChange?.(e.target.value)}

--- a/src/pages/GroupSettingPage.tsx
+++ b/src/pages/GroupSettingPage.tsx
@@ -1,5 +1,67 @@
+import Button from '@/components/common/ButtonContainer/Button/Button';
+import InputContainer from '@/components/common/InputContainer/InputContainer';
+import SettingHeaderContainer from '@/components/common/SettingHeaderContainer/SettingHeaderContainer';
+import GroupMemberManageContainer from '@/components/GroupMemberManagerContainer/GroupMemberManageContainer';
+import InviteLinkContainer from '@/components/InviteLinkContainer/InviteLinkContainer';
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+
 const GroupSettingPage = () => {
-  return <div>GroupSettingPage</div>;
+  const dummyData = {
+    groupName: '우리집 꾸미기 모임',
+    isLeader: true,
+    currentUser: '영희',
+    members: ['영희', '철수', '민수', '지영', '수진'],
+  };
+
+  const navigate = useNavigate();
+  const [groupName, setGroupName] = useState(dummyData.groupName);
+  const [isEdited, setIsEdited] = useState(false);
+
+  const handleMovePreset = () => {
+    navigate('/main/preset-setting');
+  };
+
+  const handleGroupNameChange = (value: string) => {
+    setGroupName(value);
+    setIsEdited(value !== dummyData.groupName);
+  };
+
+  return (
+    <>
+      <div className='fixed left-0 right-0 top-0 z-10 m-auto max-w bg-white03'>
+        <SettingHeaderContainer
+          title='그룹 설정'
+          isNeededBackBtn={false}
+          isNeededDoneBtn={isEdited}
+        />
+      </div>
+      <div className='flex flex-col gap-4 px-5 pt-20'>
+        <InputContainer
+          label='공간 이름'
+          value={groupName}
+          disabled={!dummyData.isLeader}
+          handleChange={handleGroupNameChange}
+        />
+        <GroupMemberManageContainer
+          leader={dummyData.isLeader}
+          members={dummyData.members}
+          currentUser={dummyData.currentUser}
+        />
+        <InviteLinkContainer />
+        <div className='flex flex-col gap-2'>
+          <p className='text-14'>프리셋 관리</p>
+          <Button
+            variant='full'
+            size='large'
+            label='프리셋 수정하기'
+            handleClick={handleMovePreset}
+            className='h-12 rounded-full text-16 text-white02'
+          />
+        </div>
+      </div>
+    </>
+  );
 };
 
 export default GroupSettingPage;


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약

> 그룹 설정 페이지

## 📌 이슈 넘버

> #130 

## 📝 작업 내용
- 그룹 설정 페이지 추가
- 그룹원 컴포넌트, 그룹명 컴포넌트, 초대 링크 컴포넌트 스타일 코드 수정
- button 컴포넌트 custom가능하게 수정

## 📸 스크린샷(선택)
그룹장인 경우
![image](https://github.com/user-attachments/assets/e8269307-c4d8-458d-8351-05b6f5ecc501)

그룹장이고 수정한 경우
![image](https://github.com/user-attachments/assets/0841243b-0533-4545-a090-fd5ac505cf90)

그룹장 아닌 경우
![image](https://github.com/user-attachments/assets/ca1660a3-6d91-48fc-9e05-03608feca0cb)

전체샷
![image](https://github.com/user-attachments/assets/17e37830-68df-40eb-95b5-8f56811815ce)


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
