### PR TITLE
Feature/#129-add-PresetAddContainer

### DIFF
--- a/src/components/PresetAddContainer/PresetAddContainer.stories.ts
+++ b/src/components/PresetAddContainer/PresetAddContainer.stories.ts
@@ -1,0 +1,15 @@
+import PresetAddContainer from '@/components/PresetAddContainer/PresetAddContainer';
+import type { Meta, StoryObj } from '@storybook/react';
+
+const meta: Meta<typeof PresetAddContainer> = {
+  title: 'Components/PresetAddContainer',
+  component: PresetAddContainer,
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof PresetAddContainer>;
+
+export const Default: Story = {
+  args: {},
+};

--- a/src/components/PresetAddContainer/PresetAddContainer.tsx
+++ b/src/components/PresetAddContainer/PresetAddContainer.tsx
@@ -1,0 +1,15 @@
+import PresetCategory from '@/components/PresetAddContainer/PresetCategory/PresetCategory';
+import React from 'react';
+
+interface PresetAddContainerProps {}
+
+const PresetAddContainer: React.FC<PresetAddContainerProps> = ({}) => {
+  return (
+    <div className='rounded-t-2xl pb-2 pt-4 shadow-[0_-4px_6px_-1px_rgba(0,0,0,0.1)]'>
+      <PresetCategory />
+      <input className='w-full p-5 focus:outline-none' placeholder='집안일을 입력해주세요' />
+    </div>
+  );
+};
+
+export default PresetAddContainer;

--- a/src/components/PresetAddContainer/PresetCategory/PresetCategory.stories.ts
+++ b/src/components/PresetAddContainer/PresetCategory/PresetCategory.stories.ts
@@ -1,0 +1,15 @@
+import PresetCategory from '@/components/PresetAddContainer/PresetCategory/PresetCategory';
+import type { Meta, StoryObj } from '@storybook/react';
+
+const meta: Meta<typeof PresetCategory> = {
+  title: 'Components/PresetAddContainer/PresetCategory',
+  component: PresetCategory,
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof PresetCategory>;
+
+export const Default: Story = {
+  args: {},
+};

--- a/src/components/PresetAddContainer/PresetCategory/PresetCategory.tsx
+++ b/src/components/PresetAddContainer/PresetCategory/PresetCategory.tsx
@@ -1,0 +1,14 @@
+const PresetCategory = () => {
+  const category = ['거실', '주방', '욕실', '침실', '기타'];
+  return (
+    <div className='flex px-5'>
+      {category.map(cate => (
+        <button key={cate} className='pr-4 text-14'>
+          {cate}
+        </button>
+      ))}
+    </div>
+  );
+};
+
+export default PresetCategory;

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -85,10 +85,6 @@ export const router = createBrowserRouter([
         element: <GroupSettingPage />,
       },
       {
-        path: 'preset-setting',
-        element: <PresetSettingPage />,
-      },
-      {
         path: 'my-page',
         element: <MyPage />,
       },
@@ -97,6 +93,10 @@ export const router = createBrowserRouter([
         element: <MyPageEditPage />,
       },
     ],
+  },
+  {
+    path: '/group-setting/preset-setting',
+    element: <PresetSettingPage />,
   },
   {
     path: '/add-housework/step1',


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약

> ex) 메인페이지 - 라우트 연결

프리셋 추가하는 컨테이너를 구현했습니다.

## 📌 이슈 넘버

> ex) #이슈번호, #이슈번호

#129 

## 📝 작업 내용

## 📸 스크린샷(선택)

![image](https://github.com/user-attachments/assets/6c646fd9-b32b-4ea8-804e-9253f052a080)


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
