### PR TITLE
Feature/#114 월간 통계 잔디 추가

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@emotion/styled": "^11.13.0",
         "@mui/material": "^6.1.7",
         "@mui/x-date-pickers": "^7.22.2",
+        "@nivo/calendar": "^0.88.0",
         "@nivo/core": "^0.88.0",
         "@radix-ui/react-dialog": "^1.1.2",
         "@radix-ui/react-dropdown-menu": "^2.1.2",
@@ -1538,6 +1539,51 @@
         "react": "^17.0.0 || ^18.0.0"
       }
     },
+    "node_modules/@nivo/calendar": {
+      "version": "0.88.0",
+      "resolved": "https://registry.npmjs.org/@nivo/calendar/-/calendar-0.88.0.tgz",
+      "integrity": "sha512-sTpoaN5bNRwywRIVKAv7oo+/ZZjX0cjBcpbyFQZqXnEmFX8tEO55Rn/469zWDG776Gk7wHcuwmQfEIqwWM9PfQ==",
+      "dependencies": {
+        "@nivo/core": "0.88.0",
+        "@nivo/legends": "0.88.0",
+        "@nivo/tooltip": "0.88.0",
+        "@types/d3-scale": "^4.0.8",
+        "@types/d3-time": "^1.0.10",
+        "@types/d3-time-format": "^3.0.0",
+        "d3-scale": "^4.0.2",
+        "d3-time": "^1.0.10",
+        "d3-time-format": "^3.0.0",
+        "lodash": "^4.17.21"
+      },
+      "peerDependencies": {
+        "react": ">= 16.14.0 < 19.0.0"
+      }
+    },
+    "node_modules/@nivo/calendar/node_modules/d3-time": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-1.1.0.tgz",
+      "integrity": "sha512-Xh0isrZ5rPYYdqhAVk8VLnMEidhz5aP7htAADH6MfzgmmicPkTo8LhkLxci61/lCB7n7UmE3bN0leRt+qvkLxA=="
+    },
+    "node_modules/@nivo/colors": {
+      "version": "0.88.0",
+      "resolved": "https://registry.npmjs.org/@nivo/colors/-/colors-0.88.0.tgz",
+      "integrity": "sha512-IZ+leYIqAlo7dyLHmsQwujanfRgXyoQ5H7PU3RWLEn1PP0zxDKLgEjFEDADpDauuslh2Tx0L81GNkWR6QSP0Mw==",
+      "dependencies": {
+        "@nivo/core": "0.88.0",
+        "@types/d3-color": "^3.0.0",
+        "@types/d3-scale": "^4.0.8",
+        "@types/d3-scale-chromatic": "^3.0.0",
+        "@types/prop-types": "^15.7.2",
+        "d3-color": "^3.1.0",
+        "d3-scale": "^4.0.2",
+        "d3-scale-chromatic": "^3.0.0",
+        "lodash": "^4.17.21",
+        "prop-types": "^15.7.2"
+      },
+      "peerDependencies": {
+        "react": ">= 16.14.0 < 19.0.0"
+      }
+    },
     "node_modules/@nivo/core": {
       "version": "0.88.0",
       "resolved": "https://registry.npmjs.org/@nivo/core/-/core-0.88.0.tgz",
@@ -1559,6 +1605,20 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/nivo/donate"
+      },
+      "peerDependencies": {
+        "react": ">= 16.14.0 < 19.0.0"
+      }
+    },
+    "node_modules/@nivo/legends": {
+      "version": "0.88.0",
+      "resolved": "https://registry.npmjs.org/@nivo/legends/-/legends-0.88.0.tgz",
+      "integrity": "sha512-d4DF9pHbD8LmGJlp/Gp1cF4e8y2wfQTcw3jVhbZj9zkb7ZWB7JfeF60VHRfbXNux9bjQ9U78/SssQqueVDPEmg==",
+      "dependencies": {
+        "@nivo/colors": "0.88.0",
+        "@nivo/core": "0.88.0",
+        "@types/d3-scale": "^4.0.8",
+        "d3-scale": "^4.0.2"
       },
       "peerDependencies": {
         "react": ">= 16.14.0 < 19.0.0"
@@ -3739,10 +3799,28 @@
         "@babel/types": "^7.20.7"
       }
     },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A=="
+    },
     "node_modules/@types/d3-path": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.0.tgz",
       "integrity": "sha512-P2dlU/q51fkOc/Gfl3Ul9kicV7l+ra934qBFXCFhrZMOL6du1TM0pm1ThYvENukyOn5h9v+yMJ9Fn5JK4QozrQ=="
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.8.tgz",
+      "integrity": "sha512-gkK1VVTr5iNiYJ7vWDI+yUFFlszhNMtVeneJ6lUTKPjprsvLLI9/tgEGiXJOnlINJA8FyA88gfnQsHbybVZrYQ==",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-scale-chromatic": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale-chromatic/-/d3-scale-chromatic-3.0.3.tgz",
+      "integrity": "sha512-laXM4+1o5ImZv3RpFAsTRn3TEkzqkytiOY0Dz0sq5cnd1dtNlk6sHLon4OvqaiJb28T0S/TdsBI3Sjsy+keJrw=="
     },
     "node_modules/@types/d3-shape": {
       "version": "3.1.6",
@@ -3751,6 +3829,16 @@
       "dependencies": {
         "@types/d3-path": "*"
       }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-1.1.4.tgz",
+      "integrity": "sha512-JIvy2HjRInE+TXOmIGN5LCmeO0hkFZx5f9FZ7kiN+D+YTcc8pptsiLiuHsvwxwC7VVKmJ2ExHUgNlAiV7vQM9g=="
+    },
+    "node_modules/@types/d3-time-format": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time-format/-/d3-time-format-3.0.4.tgz",
+      "integrity": "sha512-or9DiDnYI1h38J9hxKEsw513+KVuFbEVhl7qdxcaudoiqWWepapUen+2vAriFGexr6W5+P4l9+HJrB39GG+oRg=="
     },
     "node_modules/@types/doctrine": {
       "version": "0.0.9",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@emotion/styled": "^11.13.0",
     "@mui/material": "^6.1.7",
     "@mui/x-date-pickers": "^7.22.2",
+    "@nivo/calendar": "^0.88.0",
     "@nivo/core": "^0.88.0",
     "@radix-ui/react-dialog": "^1.1.2",
     "@radix-ui/react-dropdown-menu": "^2.1.2",

--- a/src/components/MonthlyStatisticsContainer/MonthlyGrass/MonthlyGrass.stories.tsx
+++ b/src/components/MonthlyStatisticsContainer/MonthlyGrass/MonthlyGrass.stories.tsx
@@ -1,0 +1,16 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import MonthlyGrass from './MonthlyGrass';
+
+const meta = {
+  title: 'Components/MonthlyStatisticsContainer/MonthlyGrass',
+  component: MonthlyGrass,
+  tags: ['autodocs'],
+} satisfies Meta<typeof MonthlyGrass>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {},
+  decorators: [Story => <Story />],
+};

--- a/src/components/MonthlyStatisticsContainer/MonthlyGrass/MonthlyGrass.tsx
+++ b/src/components/MonthlyStatisticsContainer/MonthlyGrass/MonthlyGrass.tsx
@@ -135,7 +135,7 @@ const MonthlyGrass: React.FC<MonthlyGrassProps> = ({}) => {
     <div className='h-80 max-w'>
       <ResponsiveTimeRange
         data={data}
-        from='2024-05-01'
+        from='2024-04-30'
         to='2024-05-31'
         emptyColor='#ffffff'
         colors={['#eeeeff', '#D8D8D8', '#989393']}
@@ -143,6 +143,7 @@ const MonthlyGrass: React.FC<MonthlyGrassProps> = ({}) => {
         dayRadius={50}
         dayBorderWidth={5}
         daySpacing={5}
+        firstWeekday='monday'
         direction='vertical'
         minValue={0}
         maxValue={30}

--- a/src/components/MonthlyStatisticsContainer/MonthlyGrass/MonthlyGrass.tsx
+++ b/src/components/MonthlyStatisticsContainer/MonthlyGrass/MonthlyGrass.tsx
@@ -1,0 +1,156 @@
+import { ResponsiveTimeRange } from '@nivo/calendar';
+
+interface MonthlyGrassProps {}
+
+const MonthlyGrass: React.FC<MonthlyGrassProps> = ({}) => {
+  const data = [
+    {
+      value: 17,
+      day: '2024-05-01',
+    },
+    {
+      value: 28,
+      day: '2024-05-02',
+    },
+    {
+      value: 1,
+      day: '2024-05-03',
+    },
+    {
+      value: 2,
+      day: '2024-05-04',
+    },
+    {
+      value: 19,
+      day: '2024-05-05',
+    },
+    {
+      value: 26,
+      day: '2024-05-06',
+    },
+    {
+      value: 35,
+      day: '2024-05-07',
+    },
+    {
+      value: 23,
+      day: '2024-05-08',
+    },
+    {
+      value: 22,
+      day: '2024-05-09',
+    },
+    {
+      value: 24,
+      day: '2024-05-10',
+    },
+    {
+      value: 15,
+      day: '2024-05-11',
+    },
+    {
+      value: 4,
+      day: '2024-05-12',
+    },
+    {
+      value: 18,
+      day: '2024-05-13',
+    },
+    {
+      value: 19,
+      day: '2024-05-14',
+    },
+    {
+      value: 20,
+      day: '2024-05-15',
+    },
+    {
+      value: 29,
+      day: '2024-05-16',
+    },
+    {
+      value: 19,
+      day: '2024-05-17',
+    },
+    {
+      value: 5,
+      day: '2024-05-18',
+    },
+    {
+      value: 17,
+      day: '2024-05-19',
+    },
+    {
+      value: 13,
+      day: '2024-05-20',
+    },
+    {
+      value: 21,
+      day: '2024-05-21',
+    },
+    {
+      value: 37,
+      day: '2024-05-22',
+    },
+    {
+      value: 0,
+      day: '2024-05-23',
+    },
+    {
+      value: 13,
+      day: '2024-05-24',
+    },
+    {
+      value: 29,
+      day: '2024-05-25',
+    },
+    {
+      value: 15,
+      day: '2024-05-26',
+    },
+    {
+      value: 10,
+      day: '2024-05-27',
+    },
+    {
+      value: 3,
+      day: '2024-05-28',
+    },
+    {
+      value: 11,
+      day: '2024-05-29',
+    },
+    {
+      value: 6,
+      day: '2024-05-30',
+    },
+    {
+      value: 26,
+      day: '2024-05-31',
+    },
+  ];
+  // TODO: rect 위에 숫자 표시
+
+  return (
+    <div className='h-80 max-w'>
+      <ResponsiveTimeRange
+        data={data}
+        from='2024-05-01'
+        to='2024-05-31'
+        emptyColor='#ffffff'
+        colors={['#eeeeff', '#D8D8D8', '#989393']}
+        margin={{ top: 0, right: 0, bottom: 0, left: 0 }}
+        dayRadius={50}
+        dayBorderWidth={5}
+        daySpacing={5}
+        direction='vertical'
+        minValue={0}
+        maxValue={30}
+        dayBorderColor='#ffffff'
+        legends={[]}
+      />
+    </div>
+  );
+};
+
+export default MonthlyGrass;

--- a/src/components/MonthlyStatisticsContainer/MonthlyStatisticsContainer.tsx
+++ b/src/components/MonthlyStatisticsContainer/MonthlyStatisticsContainer.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+
+interface MonthlyStatisticsContainerProps {}
+
+const MonthlyStatisticsContainer: React.FC<MonthlyStatisticsContainerProps> = ({}) => {
+  return (
+    <div>
+      <p>월간 통계다~~~~</p>
+    </div>
+  );
+};
+
+export default MonthlyStatisticsContainer;


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약

> 월간 통계 페이지 - 잔디

## 📌 이슈 넘버

> #114

## 📝 작업 내용
- 월간 통계 컨테이너 파일 생성
- 월간 통계 잔디 컴포넌트 추가

## 📸 스크린샷(선택)
![image](https://github.com/user-attachments/assets/80d08da8-a629-41b3-9faa-0d478fd02f8a)
![image](https://github.com/user-attachments/assets/31bc1f7e-7cdf-4f08-9f7b-395ee2e62a90)


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
