### PR TITLE
Featrue/#127-add-PresetItemContainer

### DIFF
--- a/src/components/PresetItemContainer/PresetItemContainer.stories.ts
+++ b/src/components/PresetItemContainer/PresetItemContainer.stories.ts
@@ -1,0 +1,15 @@
+import PresetItemContainer from '@/components/PresetItemContainer/PresetItemContainer';
+import type { Meta, StoryObj } from '@storybook/react';
+
+const meta: Meta<typeof PresetItemContainer> = {
+  title: 'Components/PresetItemContainer',
+  component: PresetItemContainer,
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof PresetItemContainer>;
+
+export const Default: Story = {
+  args: {},
+};

--- a/src/components/PresetItemContainer/PresetItemContainer.tsx
+++ b/src/components/PresetItemContainer/PresetItemContainer.tsx
@@ -1,0 +1,30 @@
+import PresetItem from '@/components/common/PresetItem/PresetItem';
+import { useState } from 'react';
+
+const PresetItemContainer = () => {
+  const [isShowDeleteBtn, setIsShowDeleteBtn] = useState(false);
+
+  const handleSettingClick = () => {
+    console.log('삭제버튼 등장이요');
+    setIsShowDeleteBtn(true);
+  };
+
+  const handleDeleteClick = () => {
+    console.log('삭제했습니다.');
+    setIsShowDeleteBtn(false);
+  };
+  return (
+    <div className='flex'>
+      <PresetItem
+        category='거실'
+        housework='쓰레기통 비우기'
+        handleSettingClick={handleSettingClick}
+        isInPresetSetting={true}
+        isShowDeleteBtn={isShowDeleteBtn}
+        handleDeleteClick={handleDeleteClick}
+      />
+    </div>
+  );
+};
+
+export default PresetItemContainer;

--- a/src/components/PresetTabContainer/PresetTabContainer.tsx
+++ b/src/components/PresetTabContainer/PresetTabContainer.tsx
@@ -35,7 +35,7 @@ const PresetTabContainer: React.FC<PresetTabContainerProps> = ({ data }) => {
               <PresetItem
                 category={tabData.category}
                 housework={item.description}
-                handleClick={() => handleClick(item.description)}
+                handleSelectClick={() => handleClick(item.description)}
               />
             </div>
           ))}

--- a/src/components/common/PresetItem/PresetItem.stories.ts
+++ b/src/components/common/PresetItem/PresetItem.stories.ts
@@ -15,6 +15,10 @@ export const Default: Story = {
   args: {
     category: '거실',
     housework: '쓰레기통 비우기',
-    handleClick: () => console.log('preset item clicked!'),
+    handleSelectClick: () => console.log('preset item clicked!'),
+    isInPresetSetting: false,
+    handleSettingClick: () => console.log('preset item clicked!'),
+    isShowDeleteBtn: false,
+    handleDeleteClick: () => console.log('preset item clicked!'),
   },
 };

--- a/src/components/common/PresetItem/PresetItem.tsx
+++ b/src/components/common/PresetItem/PresetItem.tsx
@@ -7,18 +7,51 @@ export interface PresetItemProps extends HouseworkCategoryTagProps {
   /** 집안일 */
   housework: string;
   /** 클릭시 호출 함수 */
-  handleClick: () => void;
+  handleSelectClick?: () => void;
+  /** 프리셋 관리에 있냐 */
+  isInPresetSetting?: boolean;
+  /** 관리버튼 클릭? */
+  handleSettingClick?: () => void;
+  /** 삭제버튼이 보여지냐 */
+  isShowDeleteBtn?: boolean;
+  /** 삭제버튼 클릭? */
+  handleDeleteClick?: () => void;
 }
 
-const PresetItem: React.FC<PresetItemProps> = ({ category, housework, handleClick }) => {
+const PresetItem: React.FC<PresetItemProps> = ({
+  category,
+  housework,
+  handleSelectClick,
+  isInPresetSetting,
+  handleSettingClick,
+  isShowDeleteBtn,
+  handleDeleteClick,
+}) => {
   return (
-    <li
-      className='flex w-full cursor-pointer list-none items-center border-b p-5'
-      onClick={handleClick}
-    >
-      <HouseworkCategoryTag category={category} />
-      <p className='pl-4 text-14'>{housework}</p>
-    </li>
+    <>
+      <li
+        className={`flex flex-1 cursor-pointer list-none items-center justify-between border-b pl-5 ${isInPresetSetting ? '' : 'p-5'}`}
+        onClick={handleSelectClick}
+      >
+        <div className='flex items-center'>
+          <HouseworkCategoryTag category={category} />
+          <p className='pl-4 text-14'>{housework}</p>
+        </div>
+        {isInPresetSetting && (
+          <div className='flex items-center'>
+            {isShowDeleteBtn ? (
+              <button className='bg-gray03 p-5' onClick={handleDeleteClick}>
+                삭제
+              </button>
+            ) : (
+              <div className='p-5'>
+                <button onClick={handleSettingClick}>선택</button>
+              </div>
+            )}
+          </div>
+        )}
+      </li>
+    </>
   );
 };
 


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약

> ex) 메인페이지 - 라우트 연결

프리센 관리에서 아이템에 삭제할 수 있는 버튼이 뜨도록 구현햇습니다.

## 📌 이슈 넘버

> ex) #이슈번호, #이슈번호

#127 

## 📝 작업 내용

## 📸 스크린샷(선택)

![image](https://github.com/user-attachments/assets/39b18f12-4335-4cdd-9428-456ceb6ec633)
![image](https://github.com/user-attachments/assets/6028dd0f-b42d-4880-9d38-cd00d5b00512)


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
