### PR TITLE
Feature/#112-주간 나머지 랭킹 컴포넌트 추가

### DIFF
--- a/src/components/WeeklyRankingContainer/WeeklyOthers/WeeklyOthers.stories.tsx
+++ b/src/components/WeeklyRankingContainer/WeeklyOthers/WeeklyOthers.stories.tsx
@@ -1,0 +1,53 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import WeeklyOthers from '@/components/WeeklyRankingContainer/WeeklyOthers/WeeklyOthers';
+
+const meta = {
+  title: 'components/WeeklyRankingContainer/WeeklyOthers',
+  component: WeeklyOthers,
+  tags: ['autodocs'],
+} satisfies Meta<typeof WeeklyOthers>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    place: 4,
+    profile: 'none',
+    name: '준희',
+    num: 1,
+  },
+  render: args => <WeeklyOthers {...args} />,
+};
+
+const args2 = {
+  place: 5,
+  profile: 'none',
+  name: '준희',
+  num: 0,
+};
+
+const args3 = {
+  place: 6,
+  profile: 'none',
+  name: '지원',
+  num: 0,
+};
+
+export const Flex: Story = {
+  args: {
+    place: 4,
+    profile: 'none',
+    name: '민지',
+    num: 1,
+  },
+
+  render: args => (
+    <div className='flex flex-col gap-2'>
+      <WeeklyOthers {...args} />
+      <WeeklyOthers {...args2} />
+      <WeeklyOthers {...args3} />
+    </div>
+  ),
+};

--- a/src/components/WeeklyRankingContainer/WeeklyOthers/WeeklyOthers.tsx
+++ b/src/components/WeeklyRankingContainer/WeeklyOthers/WeeklyOthers.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+
+interface WeeklyOthersProps {
+  /** 등수 */
+  place: number;
+  /** 프로필 이미지 */
+  profile: string;
+  /** 이름 */
+  name: string;
+  /** 완료한 집안일 개수 */
+  num: number;
+}
+
+const WeeklyOthers: React.FC<WeeklyOthersProps> = ({ place, profile, name, num }) => {
+  return (
+    <div className='flex items-center justify-between'>
+      <div className='flex items-center gap-2'>
+        <p>{place}</p>
+        <div className='flex h-8 w-8 items-center justify-center rounded-full border border-solid'>
+          <img src={profile} alt='' />
+        </div>
+        <p>{name}</p>
+      </div>
+      <p>{num}개</p>
+    </div>
+  );
+};
+
+export default WeeklyOthers;


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약

> 통계페이지 - 주간 나머지 랭킹 컴포넌트 추가

## 📌 이슈 넘버

> #112 

## 📝 작업 내용
- 위 내용과 동일

## 📸 스크린샷(선택)
![image](https://github.com/user-attachments/assets/2e5b9ebd-d5e7-426a-990c-bd384e9a9fbc)
![image](https://github.com/user-attachments/assets/8c519f70-9fd6-4d7e-b6be-88a112d9a531)


## 💬리뷰 요구사항(선택)

> 수정사항 있으면 말씀해주세요!
