### PR TITLE
Feature/#172-회원가입 안내문구 컴포넌트 추가

### DIFF
--- a/src/components/register/RegisterNotice.stories.ts
+++ b/src/components/register/RegisterNotice.stories.ts
@@ -1,0 +1,18 @@
+import RegisterNotice from '@/components/register/RegisterNotice';
+import type { Meta, StoryObj } from '@storybook/react';
+
+const meta: Meta<typeof RegisterNotice> = {
+  title: 'components/register/RegisterNotice',
+  component: RegisterNotice,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof RegisterNotice>;
+
+export const Default: Story = {
+  args: {},
+};

--- a/src/components/register/RegisterNotice.tsx
+++ b/src/components/register/RegisterNotice.tsx
@@ -1,0 +1,15 @@
+const RegisterNotice = () => {
+  return (
+    <div className='flex flex-col gap-2'>
+      <p className='text-12 font-semibold text-black02'>2-10자리 한글 및 영문</p>
+      <div className='flex flex-col gap-1 text-gray02'>
+        <span className='text-10'>두잇투게더는 본명 사용을 권장해요.</span>
+        <span className='text-10'>신중하게 본인을 잘 나타내는 이름을 설정해주세요.</span>
+        {/* TODO 정책 필요 */}
+        <span className='text-10'>이름은 0일마다 변경 가능합니다.</span>
+      </div>
+    </div>
+  );
+};
+
+export default RegisterNotice;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -70,6 +70,7 @@ export default {
       white03: '#FFFFFF',
     },
     fontSize: {
+      10: '0.625rem',
       12: '0.75rem',
       14: '0.875rem',
       16: '1rem',


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약

> 회원가입 안내문구 컴포넌트 추가

## 📌 이슈 넘버

> #172 

## 📝 작업 내용
- 회원가입 안내문구 컴포넌트 & 스토리북문서 추가
- 테일윈드 공통 css 파일 > fontSize 10px 단위 추가

## 📸 스크린샷(선택)
![image](https://github.com/user-attachments/assets/d48579a0-22f9-4070-918e-6f29ac3fd22c)


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
