### PR TITLE
Feature/#194-온보딩 타이틀 컴포넌트 추가

### DIFF
--- a/src/components/survey/SurveyTitle.stories.ts
+++ b/src/components/survey/SurveyTitle.stories.ts
@@ -1,0 +1,17 @@
+import SurveyTitle from '@/components/survey/SurveyTitle';
+import type { Meta, StoryObj } from '@storybook/react';
+
+const meta: Meta<typeof SurveyTitle> = {
+  title: 'components/survey/SurveyTitle',
+  component: SurveyTitle,
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof SurveyTitle>;
+
+export const Default: Story = {
+  args: {
+    title: `당신만의 청소 스타일을\n완성해보세요`,
+  },
+};

--- a/src/components/survey/SurveyTitle.tsx
+++ b/src/components/survey/SurveyTitle.tsx
@@ -1,0 +1,9 @@
+interface SurveyTitleProps {
+  title: string;
+}
+
+const SurveyTitle = ({ title }: SurveyTitleProps) => {
+  return <p className='whitespace-pre-line text-24 font-semibold text-black02'>{title}</p>;
+};
+
+export default SurveyTitle;


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약

> 온보딩페이지-타이틀 컴포넌트 추가

## 📌 이슈 넘버

> #194 

## 📝 작업 내용
- 온보딩 타이틀 컴포넌트 추가

## 📸 스크린샷(선택)
![image](https://github.com/user-attachments/assets/69302cd9-b079-4d34-af19-d1566033e964)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
