### PR TITLE
Feature/#147 월간 통계 페이지 추가

### DIFF
--- a/src/components/statistics/monthly/CompletionDate/CompletionDate.tsx
+++ b/src/components/statistics/monthly/CompletionDate/CompletionDate.tsx
@@ -1,9 +1,9 @@
 interface CompletionDateProps {
   date: string;
-  color: string;
+  color?: string;
 }
 
-const CompletionDate: React.FC<CompletionDateProps> = ({ date, color }) => {
+const CompletionDate: React.FC<CompletionDateProps> = ({ date, color = 'text-[#989393]' }) => {
   return (
     <div className={`flex items-center gap-2 ${color}`}>
       <i className='h-4 w-4 border border-solid border-black02'></i>

--- a/src/components/statistics/monthly/CompletionRate/CompletionRate.stories.tsx
+++ b/src/components/statistics/monthly/CompletionRate/CompletionRate.stories.tsx
@@ -4,9 +4,7 @@ import CompletionRate from './CompletionRate';
 const meta = {
   title: 'components/statistics/monthly/CompletionRate',
   component: CompletionRate,
-  parameters: {
-    layout: 'centered',
-  },
+
   tags: ['autodocs'],
   argTypes: {
     rate: {

--- a/src/components/statistics/monthly/CompletionRate/CompletionRate.tsx
+++ b/src/components/statistics/monthly/CompletionRate/CompletionRate.tsx
@@ -7,26 +7,26 @@ interface CompletionRateProps {
 
 const CompletionRate: React.FC<CompletionRateProps> = ({
   rate,
-  size = 24,
+  size = 4,
   bgColor = '#f9f9f9',
   gageColor = '#989393',
 }) => {
-  const radius = 16;
+  const radius = 4;
   const circumference = 2 * Math.PI * radius;
   const validRate = Math.min(100, Math.max(0, rate));
   const offset = circumference - (validRate / 100) * circumference;
 
   return (
-    <div className={`size-${size} relative flex items-center`}>
-      <svg className='size-full -rotate-90' viewBox='0 0 100 100'>
-        <circle cx='50' cy='50' r={radius} fill='none' stroke={bgColor} strokeWidth='10' />
+    <div className={`size-${size} relative flex items-center gap-1`}>
+      <svg className='size-full -rotate-90' viewBox='0 0 12 12'>
+        <circle cx='6' cy='6' r='4' fill='none' stroke={bgColor} strokeWidth='3' />
         <circle
-          cx='50'
-          cy='50'
-          r={radius}
+          cx='6'
+          cy='6'
+          r='4'
           fill='none'
           stroke={gageColor}
-          strokeWidth='10'
+          strokeWidth='3'
           style={{
             strokeDasharray: `${circumference}`,
             strokeDashoffset: offset,
@@ -34,7 +34,7 @@ const CompletionRate: React.FC<CompletionRateProps> = ({
           }}
         />
       </svg>
-      <span className='-translate-x-3 text-16' style={{ color: gageColor }}>
+      <span className='text-16' style={{ color: gageColor }}>
         {validRate}%
       </span>
     </div>

--- a/src/index.css
+++ b/src/index.css
@@ -122,12 +122,18 @@ body:has(.react-modal-sheet-container) {
 .react-calendar__month-view__weekdays .react-calendar__month-view__weekdays__weekday {
   @apply hidden;
 }
-.react-calendar__month-view__days__day {
-  @apply aspect-square w-10 rounded-full;
-}
 .react-calendar__viewContainer {
-  @apply flex justify-center;
+  @apply flex w-full justify-center;
+}
+.react-calendar__month-view {
+  @apply w-full;
 }
 .react-calendar__month-view__days {
-  @apply !grid !grid-cols-7 gap-2;
+  @apply !grid w-full !grid-cols-7 justify-items-center gap-1;
+}
+.react-calendar__month-view__days__day {
+  @apply flex aspect-square w-10 items-center justify-center rounded-full;
+}
+.react-calendar__month-view__weekdays {
+  @apply !grid !grid-cols-7 !gap-0;
 }

--- a/src/pages/MonthlyStatisticsPage.tsx
+++ b/src/pages/MonthlyStatisticsPage.tsx
@@ -1,5 +1,56 @@
+import CompletionDate from '@/components/statistics/monthly/CompletionDate/CompletionDate';
+import CompletionRate from '@/components/statistics/monthly/CompletionRate/CompletionRate';
+import MonthlyGoodBad from '@/components/statistics/monthly/MonthlyGoodBad/MonthlyGoodBad';
+import MonthlyGrass from '@/components/statistics/monthly/MonthlyGrass/MonthlyGrass';
+
+enum CompletionStatus {
+  DONE = 'done',
+  SOSO = 'soso',
+  NO = 'no',
+}
+
 const MonthlyStatisticsPage = () => {
-  return <div>MonthlyStatisticsPage</div>;
+  const sampleCompletionData = [
+    { date: '2024-11-01', status: CompletionStatus.DONE },
+    { date: '2024-11-02', status: CompletionStatus.DONE },
+    { date: '2024-11-03', status: CompletionStatus.DONE },
+    { date: '2024-11-04', status: CompletionStatus.DONE },
+    { date: '2024-11-05', status: CompletionStatus.DONE },
+    { date: '2024-11-06', status: CompletionStatus.DONE },
+    { date: '2024-11-07', status: CompletionStatus.SOSO },
+    { date: '2024-11-07', status: CompletionStatus.NO },
+    { date: '2024-11-09', status: CompletionStatus.SOSO },
+    { date: '2024-11-10', status: CompletionStatus.SOSO },
+    { date: '2024-11-11', status: CompletionStatus.DONE },
+    { date: '2024-11-12', status: CompletionStatus.DONE },
+    { date: '2024-11-13', status: CompletionStatus.DONE },
+    { date: '2024-11-14', status: CompletionStatus.DONE },
+    { date: '2024-11-16', status: CompletionStatus.SOSO },
+    { date: '2024-11-17', status: CompletionStatus.SOSO },
+    { date: '2024-11-18', status: CompletionStatus.DONE },
+    { date: '2024-11-19', status: CompletionStatus.SOSO },
+    { date: '2024-11-20', status: CompletionStatus.DONE },
+    { date: '2024-11-21', status: CompletionStatus.DONE },
+    { date: '2024-11-23', status: CompletionStatus.SOSO },
+    { date: '2024-11-24', status: CompletionStatus.DONE },
+    { date: '2024-11-26', status: CompletionStatus.DONE },
+    { date: '2024-11-27', status: CompletionStatus.DONE },
+    { date: '2024-11-28', status: CompletionStatus.DONE },
+  ];
+
+  return (
+    <div className='flex flex-col gap-5'>
+      <MonthlyGrass completionData={sampleCompletionData} />
+      <div className='flex h-8 justify-between'>
+        <CompletionRate rate={80} />
+        <CompletionDate date='18' />
+      </div>
+      <div className='flex gap-3'>
+        <MonthlyGoodBad type='칭찬' name='꼼시' />
+        <MonthlyGoodBad type='찌르기' name='꼼시' />
+      </div>
+    </div>
+  );
 };
 
 export default MonthlyStatisticsPage;


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약

> 통계 페이지 - 월간

## 📌 이슈 넘버

> #147

## 📝 작업 내용
- 캘린더 반응형 처리
- 완료율 컴포넌트 크기 처리
- 스토리북 코드 수정
- 완료일 color props 선택으로 처리
- 월간 통계 페이지 완료

## 📸 스크린샷(선택)
![image](https://github.com/user-attachments/assets/cfe99404-848c-4330-879f-1605bc7f8596)


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
