### PR TITLE
Feature/#183-온보딩 조사페이지 STEP 4 추가

### DIFF
--- a/src/components/survey/OnBoarding.tsx
+++ b/src/components/survey/OnBoarding.tsx
@@ -22,6 +22,7 @@ const DUMMY_QUESTION_STEP2 = [
   '가족이나 동거인의 요구',
 ];
 const DUMMY_QUESTION_STEP3 = ['시간부족', '적합한 도구나 제품 부족', '체력부족', '동기부족'];
+const DUMMY_QUESTION_STEP4 = ['거실', '주방', '화장실', '침실'];
 
 interface OnBoardingProps {}
 
@@ -51,6 +52,7 @@ const OnBoarding: React.FC<OnBoardingProps> = ({}) => {
 
       <Progress value={(step / 5) * 100} className='mb-8' />
       <div className='flex h-screen flex-col gap-8 px-5'>
+        {/* TODO STEP 동일구조라서 hook 으로 사용 고려 */}
         {step === 1 && (
           <Step1
             title={`집안일 청소는\n얼마나 자주 하세요?`}
@@ -69,6 +71,13 @@ const OnBoarding: React.FC<OnBoardingProps> = ({}) => {
           <Step3
             title={`청소할 때 가장 어려운 점은\n무엇인가요?`}
             questions={DUMMY_QUESTION_STEP3}
+            handleAnswer={setAnswer}
+          />
+        )}
+        {step === 4 && (
+          <Step3
+            title={`청소할 때 최우선으로\n신경 쓰는 공간을 알려주세요!`}
+            questions={DUMMY_QUESTION_STEP4}
             handleAnswer={setAnswer}
           />
         )}

--- a/src/components/survey/steps/Step4.tsx
+++ b/src/components/survey/steps/Step4.tsx
@@ -1,0 +1,38 @@
+import React, { Dispatch, SetStateAction, useState } from 'react';
+import SurveyTitle from '@/components/survey/SurveyTitle/SurveyTitle';
+import MenuSelect from '@/components/survey/MenuSelect/MenuSelect';
+
+interface Step4Props {
+  title: string;
+  questions: string[];
+  handleAnswer: Dispatch<SetStateAction<string>>;
+}
+
+const Step4: React.FC<Step4Props> = ({ title, questions, handleAnswer }) => {
+  const [activeItem, setActiveItem] = useState('');
+
+  const handleSelect = (content: string) => {
+    setActiveItem(content);
+  };
+
+  return (
+    <div className='flex flex-1 flex-col gap-3'>
+      <div className='mb-5'>
+        <SurveyTitle title={title} />
+      </div>
+
+      <div className='flex flex-wrap gap-3'>
+        {questions.map(question => (
+          <MenuSelect
+            type='tight'
+            status={activeItem === question ? 'active' : 'inActive'}
+            content={question}
+            handleSelect={() => handleSelect(question)}
+          />
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default Step4;


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약

> ex) 메인페이지 - 라우트 연결
- 온보딩 조사페이지 STEP 4 추가

## 📌 이슈 넘버

> ex) #이슈번호, #이슈번호
#183 

## 📝 작업 내용
- 온보딩 조사페이지 STEP 4 추가

## 📸 스크린샷(선택)
![image](https://github.com/user-attachments/assets/27808711-f196-455e-8697-42dc6e94e4b4)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
