### PR TITLE
Feature/#221-delete-DoneBtn

### DIFF
--- a/src/components/common/header/Header.tsx
+++ b/src/components/common/header/Header.tsx
@@ -11,9 +11,11 @@ interface HeaderProps {
 const Header: React.FC<HeaderProps> = ({ title, isNeededBackBtn, isNeededDoneBtn, onBack }) => {
   return (
     <div className='flex items-center justify-between border-b-2 border-solid border-white01 px-5 py-4'>
-      {isNeededBackBtn && <BackBtn handleClick={onBack} />}
-      <div className='flex-1 text-center'>{title}</div>
-      {isNeededDoneBtn && <button className='text-black02'>완료</button>}
+      <div className='flex-1 bg-white03'>{isNeededBackBtn && <BackBtn handleClick={onBack} />}</div>
+      <div className='flex-1 bg-white03 text-center'>{title}</div>
+      <div className='flex-1 bg-white03 text-end'>
+        {isNeededDoneBtn && <button className='text-black02'>완료</button>}
+      </div>
     </div>
   );
 };

--- a/src/pages/PresetSettingPage.tsx
+++ b/src/pages/PresetSettingPage.tsx
@@ -90,7 +90,7 @@ const PresetSettingPage = () => {
 
   return (
     <div className='flex min-h-screen flex-col'>
-      <Header title='프리셋 관리' isNeededBackBtn={true} isNeededDoneBtn={true} />
+      <Header title='프리셋 관리' isNeededBackBtn={true} isNeededDoneBtn={false} />
       <Tab activeTab={activeTab} handleSetActiveTab={setActiveTab} chargers={chargers} />
       <div className='mt-4 flex-1'>
         <PresetTab


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약

> ex) 메인페이지 - 라우트 연결

프리셋 관리에서 완료 버튼을 삭제하고
Header에서 완료버튼이 생겨도 레이아웃이 안깨지도록 수정했습니다.

## 📌 이슈 넘버

> ex) #이슈번호, #이슈번호

#221 

## 📝 작업 내용

## 📸 스크린샷(선택)

![image](https://github.com/user-attachments/assets/b6ebdf98-4dc6-4714-8e8c-7323428e6808)
![image](https://github.com/user-attachments/assets/7ab1590d-6bd6-422a-a8cf-ec3e25e3050a)


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
