### PR TITLE
Feature/#226-add-AccountSetBtn

### DIFF
--- a/src/components/my/AccountSetBtn/AccountSetBtn.stories.ts
+++ b/src/components/my/AccountSetBtn/AccountSetBtn.stories.ts
@@ -1,0 +1,13 @@
+import AccountSetBtn from '@/components/my/AccountSetBtn/AccountSetBtn';
+import type { Meta, StoryObj } from '@storybook/react';
+
+const meta = {
+  title: 'components/my/AccountSetBtn/AccountSetBtn',
+  component: AccountSetBtn,
+  tags: ['autodocs'],
+} satisfies Meta<typeof AccountSetBtn>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/src/components/my/AccountSetBtn/AccountSetBtn.tsx
+++ b/src/components/my/AccountSetBtn/AccountSetBtn.tsx
@@ -1,0 +1,10 @@
+const AccountSetBtn = () => {
+  const handleClick = () => {};
+  return (
+    <div className='flex justify-end px-5 py-4'>
+      <button className='h-5 w-5 bg-gray01' onClick={handleClick}></button>
+    </div>
+  );
+};
+
+export default AccountSetBtn;


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약

> ex) 메인페이지 - 라우트 연결

계정 관리로 가는 버튼을 구현했습니다.

## 📌 이슈 넘버

> ex) #이슈번호, #이슈번호

#226 

## 📝 작업 내용

## 📸 스크린샷(선택)

![image](https://github.com/user-attachments/assets/000fcdac-7c40-4685-9bc2-5f36800fc329)


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
