### PR TITLE
Feature/#233-add-AccountInfo

### DIFF
--- a/src/components/my/AccountInfo/AccountInfo.stories.ts
+++ b/src/components/my/AccountInfo/AccountInfo.stories.ts
@@ -1,0 +1,28 @@
+import AccountInfo from '@/components/my/AccountInfo/AccountInfo';
+import type { Meta, StoryObj } from '@storybook/react';
+
+const meta = {
+  title: 'components/my/AccountInfo/AccountInfo',
+  component: AccountInfo,
+  tags: ['autodocs'],
+  argTypes: {
+    nickname: {
+      description: '닉네임',
+      control: 'text',
+    },
+    account: {
+      description: '이메일',
+      control: 'text',
+    },
+  },
+} satisfies Meta<typeof AccountInfo>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    nickname: '스페이스엔젤',
+    account: 'example@example.com',
+  },
+};

--- a/src/components/my/AccountInfo/AccountInfo.tsx
+++ b/src/components/my/AccountInfo/AccountInfo.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+
+interface AccountInfoProps {
+  nickname: string;
+  account: string;
+}
+
+const AccountInfo: React.FC<AccountInfoProps> = ({ nickname, account }) => {
+  return (
+    <div>
+      <div>{nickname}</div>
+      <div className='text-14 text-gray03'>{account}</div>
+    </div>
+  );
+};
+
+export default AccountInfo;


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약

> ex) 메인페이지 - 라우트 연결

계정정보 컴포넌트입니다.

## 📌 이슈 넘버

> ex) #이슈번호, #이슈번호

#233 

## 📝 작업 내용

## 📸 스크린샷(선택)

![image](https://github.com/user-attachments/assets/bfa322b7-ad42-45bb-b57a-f80314740863)


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
