### PR TITLE
Feature/#228-add-SurveyAgainBtn

### DIFF
--- a/src/components/common/button/Button/Button.tsx
+++ b/src/components/common/button/Button/Button.tsx
@@ -2,7 +2,7 @@ import { Button as ButtonComponent } from '@/components/common/ui/button';
 
 interface ButtonProps {
   /** 라벨 */
-  label: string;
+  label: React.ReactNode;
   /** 타입 */
   variant: 'full' | 'outline' | 'secondary' | 'ghost' | 'link';
   /** 사이즈 */

--- a/src/components/my/SurveyAgainBtn/SurveyAgainBtn.stories.ts
+++ b/src/components/my/SurveyAgainBtn/SurveyAgainBtn.stories.ts
@@ -1,0 +1,13 @@
+import SurveyAgainBtn from '@/components/my/SurveyAgainBtn/SurveyAgainBtn';
+import type { Meta, StoryObj } from '@storybook/react';
+
+const meta = {
+  title: 'components/my/SurveyAgainBtn/SurveyAgainBtn',
+  component: SurveyAgainBtn,
+  tags: ['autodocs'],
+} satisfies Meta<typeof SurveyAgainBtn>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/src/components/my/SurveyAgainBtn/SurveyAgainBtn.tsx
+++ b/src/components/my/SurveyAgainBtn/SurveyAgainBtn.tsx
@@ -1,0 +1,25 @@
+import Button from '@/components/common/button/Button/Button';
+
+const SurveyAgainBtn = () => {
+  const handleClick = () => {
+    //survey로 이동
+  };
+  return (
+    <div className='px-5'>
+      <Button
+        variant='full'
+        handleClick={handleClick}
+        size='large'
+        className={'h-28 justify-between px-4'}
+        label={
+          <>
+            <div>내 청소 성향 다시 분석하기</div>
+            <div>이미지</div>
+          </>
+        }
+      />
+    </div>
+  );
+};
+
+export default SurveyAgainBtn;


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약

> ex) 메인페이지 - 라우트 연결

선호도 조사 다시 하는 버튼입니다.

## 📌 이슈 넘버

> ex) #이슈번호, #이슈번호

#228 

## 📝 작업 내용

## 📸 스크린샷(선택)

![image](https://github.com/user-attachments/assets/14a7b775-952c-4000-a97d-8723cfc8080b)


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
