### PR TITLE
Feature/#242-add-ProfileEditBtn

### DIFF
--- a/src/components/my/ProfileEditBtn/ProfileEditBtn.stories.ts
+++ b/src/components/my/ProfileEditBtn/ProfileEditBtn.stories.ts
@@ -1,0 +1,13 @@
+import ProfileEditBtn from '@/components/my/ProfileEditBtn/ProfileEditBtn';
+import type { Meta, StoryObj } from '@storybook/react';
+
+const meta = {
+  title: 'components/my/ProfileEditBtn/ProfileEditBtn',
+  component: ProfileEditBtn,
+  tags: ['autodocs'],
+} satisfies Meta<typeof ProfileEditBtn>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/src/components/my/ProfileEditBtn/ProfileEditBtn.tsx
+++ b/src/components/my/ProfileEditBtn/ProfileEditBtn.tsx
@@ -1,0 +1,13 @@
+const ProfileEditBtn = () => {
+  const handleClick = () => {};
+  return (
+    <button
+      className='rounded-full border-2 border-solid border-gray03 px-5 py-2 text-gray03'
+      onClick={handleClick}
+    >
+      프로필 편집
+    </button>
+  );
+};
+
+export default ProfileEditBtn;


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약

> ex) 메인페이지 - 라우트 연결

프로필 편집 버튼입니다.

## 📌 이슈 넘버

> ex) #이슈번호, #이슈번호

#242 

## 📝 작업 내용

## 📸 스크린샷(선택)

![image](https://github.com/user-attachments/assets/4768a017-cfb1-4ede-9345-f327027bc214)


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
