### PR TITLE
Feature/#231 계정 관리 페이지 추가

### DIFF
--- a/src/components/my/AccountMenuItem/AccountMenuItem.stories.tsx
+++ b/src/components/my/AccountMenuItem/AccountMenuItem.stories.tsx
@@ -1,0 +1,44 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import AccountMenuItem from './AccountMenuItem';
+
+const meta: Meta<typeof AccountMenuItem> = {
+  title: 'components/my/AccountMenuItem/AccountMenuItem',
+  component: AccountMenuItem,
+  argTypes: {
+    label: {
+      control: 'text',
+      description: '메뉴 아이템 레이블',
+    },
+    state: {
+      control: 'text',
+      description: '상태 텍스트 (선택사항)',
+    },
+    iconType: {
+      control: 'text',
+      description: '아이콘 타입 (선택사항)',
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof AccountMenuItem>;
+
+export const Default: Story = {
+  args: {
+    label: '메뉴 아이템',
+  },
+};
+
+export const WithState: Story = {
+  args: {
+    label: '메뉴 아이템',
+    state: '활성화',
+  },
+};
+
+export const WithIcon: Story = {
+  args: {
+    label: '메뉴 아이템',
+    iconType: '.',
+  },
+};

--- a/src/components/my/AccountMenuItem/AccountMenuItem.tsx
+++ b/src/components/my/AccountMenuItem/AccountMenuItem.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+
+interface AccountMenuItemProps {
+  label: string;
+  state?: string;
+  iconType?: string;
+  handleClick?: () => void;
+}
+
+const AccountMenuItem: React.FC<AccountMenuItemProps> = ({
+  label,
+  state,
+  iconType,
+  handleClick,
+}) => {
+  return (
+    <div className='w-full border-b border-solid border-white01'>
+      <div className='flex h-12 items-center justify-between px-5'>
+        <p className='text-16'>{label}</p>
+        {state && <p className='text-14'>{state}</p>}
+        {iconType && <i className='h-4 w-4 border border-solid' onClick={handleClick}></i>}
+      </div>
+    </div>
+  );
+};
+
+export default AccountMenuItem;

--- a/src/pages/AccountManagePage.tsx
+++ b/src/pages/AccountManagePage.tsx
@@ -1,0 +1,34 @@
+import Header from '@/components/common/header/Header';
+import AccountMenuItem from '@/components/my/AccountMenuItem/AccountMenuItem';
+import { useNavigate } from 'react-router-dom';
+
+const AccountManagePage = () => {
+  const navigate = useNavigate();
+  const handleBack = () => {
+    navigate('/main/my-page');
+  };
+
+  const handleLogout = () => {
+    console.log('로그아웃');
+  };
+
+  const handleLeave = () => {
+    console.log('탈퇴');
+  };
+
+  return (
+    <div>
+      <Header
+        title='계정 관리'
+        isNeededBackBtn={true}
+        isNeededDoneBtn={false}
+        handleBack={handleBack}
+      />
+      <AccountMenuItem label='카카오톡' state='연결됨' />
+      <AccountMenuItem label='로그아웃' iconType='로그아웃' handleClick={handleLogout} />
+      <AccountMenuItem label='탈퇴하기' iconType='탈퇴' handleClick={handleLeave} />
+    </div>
+  );
+};
+
+export default AccountManagePage;

--- a/src/pages/AccountManagePage.tsx
+++ b/src/pages/AccountManagePage.tsx
@@ -18,12 +18,7 @@ const AccountManagePage = () => {
 
   return (
     <div>
-      <Header
-        title='계정 관리'
-        isNeededBackBtn={true}
-        isNeededDoneBtn={false}
-        handleBack={handleBack}
-      />
+      <Header title='계정 관리' isNeededDoneBtn={false} handleBack={handleBack} />
       <AccountMenuItem label='카카오톡' state='연결됨' />
       <AccountMenuItem label='로그아웃' iconType='로그아웃' handleClick={handleLogout} />
       <AccountMenuItem label='탈퇴하기' iconType='탈퇴' handleClick={handleLeave} />

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -17,6 +17,7 @@ import MonthlyStatisticsPage from '@/pages/MonthlyStatisticsPage';
 import PresetSettingPage from '@/pages/PresetSettingPage';
 import MyPage from '@/pages/MyPage';
 import MyPageEditPage from '@/pages/MyPageEditPage';
+import AccountManagePage from '@/pages/AccountManagePage';
 import HouseWorkStepOnePage from '@/pages/HouseWorkStepOnePage';
 import HouseWorkStepTwoPage from '@/pages/HouseWorkStepTwoPage';
 import GroupInviteReceivePage from '@/pages/GroupInviteReceivePage';
@@ -86,6 +87,10 @@ export const router = createBrowserRouter([
         element: <MyPageEditPage />,
       },
     ],
+  },
+  {
+    path: 'my-page/account-manage',
+    element: <AccountManagePage />,
   },
   {
     path: '/group-setting/preset-setting',


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약

> 계정 관리 페이지 & 계정메뉴아이템 컴포넌트

## 📌 이슈 넘버

> #231

## 📝 작업 내용
- router에 계정 관리 페이지 추가
- 계정 관리 페이지 추가
- 계정 메뉴 아이템 컴포넌트 추가

## 📸 스크린샷(선택)
![image](https://github.com/user-attachments/assets/8593983e-bce7-4a4b-b8b4-ab68f7acc9b0)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
