### PR TITLE
Feature/#247-마이페이지 프로필편집 페이지 구현

### DIFF
--- a/src/components/common/profile/ProfileImg.tsx
+++ b/src/components/common/profile/ProfileImg.tsx
@@ -3,8 +3,8 @@ import { useState } from 'react';
 import React from 'react';
 
 interface ProfileImgProps {
-  width: number;
-  height: number;
+  width?: number;
+  height?: number;
 }
 
 const ProfileImg: React.FC<ProfileImgProps> = ({ width = 32, height = 32 }) => {

--- a/src/components/my/ProfileEditBtn/ProfileEditBtn.tsx
+++ b/src/components/my/ProfileEditBtn/ProfileEditBtn.tsx
@@ -1,5 +1,9 @@
+import { useNavigate } from 'react-router-dom';
 const ProfileEditBtn = () => {
-  const handleClick = () => {};
+  const navigate = useNavigate();
+  const handleClick = () => {
+    navigate('/main/my-page/edit');
+  };
   return (
     <button
       className='rounded-full border-2 border-solid border-gray03 px-5 py-2 text-gray03'

--- a/src/pages/MyPageEditPage.tsx
+++ b/src/pages/MyPageEditPage.tsx
@@ -1,5 +1,26 @@
+import Header from '@/components/common/header/Header';
+import InputWithLabel from '@/components/common/input/InputWithLabel';
+import ProfileImg from '@/components/common/profile/ProfileImg';
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+
 const MyPageEditPage = () => {
-  return <div>MyPageEditPage</div>;
+  const navigate = useNavigate();
+  const [username, setUserName] = useState<string>(''); // 수정
+  const handleBack = () => {
+    navigate('/main/my-page');
+  };
+  return (
+    <>
+      <Header title='프로필 편집' isNeededDoneBtn={false} handleBack={handleBack} />
+      <div className='mt-10 flex flex-col gap-14 px-5'>
+        <div className='m-auto'>
+          <ProfileImg />
+        </div>
+        <InputWithLabel label='이름' value={username} disabled={false} />
+      </div>
+    </>
+  );
 };
 
 export default MyPageEditPage;


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약
- 마이페이지 > 프로필편집 페이지 구현

## 📌 이슈 넘버

#247 

## 📝 작업 내용
- 마이페이지 > 프로필편집 페이지 구현
- 마이페이지 페이지 연결
- 프로필이미지 props 필수값 제거

## 📸 스크린샷(선택)
![image](https://github.com/user-attachments/assets/67a4e8b0-60fa-4a24-8a08-5785d3cbc6ec)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
