### PR TITLE
Feature/#262-그룹 설정 페이지 더미데이터 처리

### DIFF
--- a/src/components/common/header/Header.tsx
+++ b/src/components/common/header/Header.tsx
@@ -5,15 +5,20 @@ interface HeaderProps {
   title: string;
   isNeededDoneBtn: boolean;
   handleBack?: () => void;
+  handleDone?: () => void;
 }
 
-const Header: React.FC<HeaderProps> = ({ title, isNeededDoneBtn, handleBack }) => {
+const Header: React.FC<HeaderProps> = ({ title, isNeededDoneBtn, handleBack, handleDone }) => {
   return (
     <div className='flex items-center justify-between border-b-2 border-solid border-white01 px-5 py-4'>
       <div className='flex-1 bg-white03'>{handleBack && <BackBtn handleClick={handleBack} />}</div>
       <div className='flex-1 bg-white03 text-center'>{title}</div>
       <div className='flex-1 bg-white03 text-end'>
-        {isNeededDoneBtn && <button className='text-black02'>완료</button>}
+        {isNeededDoneBtn && (
+          <button className='text-black02' onClick={handleDone}>
+            완료
+          </button>
+        )}
       </div>
     </div>
   );

--- a/src/components/setting/groupSetting/MemberItems/MemberItem.tsx
+++ b/src/components/setting/groupSetting/MemberItems/MemberItem.tsx
@@ -1,6 +1,18 @@
+interface Member {
+  member_id: number;
+  name: string;
+  nickname: string;
+  role: string;
+  profile_image: {
+    profile_image_id: number;
+    url: string;
+    type: string;
+  };
+}
+
 interface MemberItemProps {
   leader: boolean;
-  member: string;
+  member: Member;
   isCurrentUser: boolean;
   handleClick: () => void;
 }
@@ -12,7 +24,7 @@ const MemberItem: React.FC<MemberItemProps> = ({ leader, member, handleClick, is
     <div
       className={`flex h-12 items-center justify-between rounded-full border border-solid border-white01 px-2 py-1 text-16 shadow-sm ${!showButton ? 'bg-white02' : ''}`}
     >
-      {member}
+      {member.name}
       {showButton && (
         <i className='h-4 w-4 border border-solid border-black02' onClick={handleClick}></i>
       )}

--- a/src/components/setting/groupSetting/MemberItems/MemberItems.tsx
+++ b/src/components/setting/groupSetting/MemberItems/MemberItems.tsx
@@ -1,11 +1,27 @@
 import MemberItem from '@/components/setting/groupSetting/MemberItems/MemberItem';
 import React from 'react';
 
+interface Member {
+  member_id: number;
+  name: string;
+  nickname: string;
+  role: string;
+  profile_image: {
+    profile_image_id: number;
+    url: string;
+    type: string;
+  };
+}
+
 interface MemberItemsProps {
   leader: boolean;
-  members: string[];
-  currentUser: string;
-  handleClick?: (member: string) => void;
+  members: Member[];
+  currentUser: {
+    member_id: number;
+    name: string;
+    nickname: string;
+  };
+  handleClick?: (member: Member) => void;
 }
 
 const MemberItems: React.FC<MemberItemsProps> = ({ leader, members, currentUser, handleClick }) => {
@@ -13,12 +29,12 @@ const MemberItems: React.FC<MemberItemsProps> = ({ leader, members, currentUser,
     <div className='flex flex-col gap-2'>
       <p className='text-14'>그룹원 관리</p>
       <div className='flex flex-col gap-2'>
-        {members.map((member, index) => (
+        {members.map(member => (
           <MemberItem
-            key={index}
+            key={member.member_id}
             leader={leader}
             member={member}
-            isCurrentUser={member === currentUser}
+            isCurrentUser={member.member_id === currentUser.member_id}
             handleClick={() => handleClick?.(member)}
           />
         ))}

--- a/src/mock/groupSettingMockData.ts
+++ b/src/mock/groupSettingMockData.ts
@@ -1,0 +1,48 @@
+export const groupSettingMockData = {
+  group: {
+    group_id: 1,
+    group_name: '우리집 꾸미기 모임',
+    created_at: '2024-11-28T00:00:00Z',
+    updated_at: null,
+  },
+  members: [
+    {
+      member_id: 1,
+      name: '리더다',
+      nickname: '리더다',
+      role: 'ADMIN',
+      profile_image: {
+        profile_image_id: 1,
+        url: 'https://example.com/image1.jpg',
+        type: 'KAKAO',
+      },
+    },
+    {
+      member_id: 2,
+      name: '멤버다',
+      nickname: '멤버다',
+      role: 'PARTICIPANT',
+      profile_image: {
+        profile_image_id: 2,
+        url: 'https://example.com/image2.jpg',
+        type: 'KAKAO',
+      },
+    },
+    {
+      member_id: 3,
+      name: '청소왕',
+      nickname: '청소왕',
+      role: 'PARTICIPANT',
+      profile_image: {
+        profile_image_id: 2,
+        url: 'https://example.com/image2.jpg',
+        type: 'KAKAO',
+      },
+    },
+  ],
+  currentUser: {
+    member_id: 1,
+    name: '리더다',
+    nickname: '리더다',
+  },
+};

--- a/src/pages/GroupSettingPage.tsx
+++ b/src/pages/GroupSettingPage.tsx
@@ -6,19 +6,15 @@ import InputWithLabel from '@/components/common/input/InputWithLabel';
 import MemberItems from '@/components/setting/groupSetting/MemberItems/MemberItems';
 import InviteLinkWithLabel from '@/components/setting/groupSetting/InviteLink/InviteLinkWithLabel';
 import ExitSheet from '@/components/setting/ExitSheet/ExitSheet';
+import { groupSettingMockData } from '@/mock/groupSettingMockData';
 
 const GroupSettingPage = () => {
-  const dummyData = {
-    groupName: '우리집 꾸미기 모임',
-    isLeader: true,
-    currentUser: '영희',
-    members: ['영희', '철수', '민수', '지영', '수진'],
-  };
-
   const navigate = useNavigate();
-  const [groupName, setGroupName] = useState(dummyData.groupName);
+
+  const [groupName, setGroupName] = useState(groupSettingMockData.group.group_name);
   const [isEdited, setIsEdited] = useState(false);
   const [isOpen, setIsOpen] = useState(false);
+
   const [tag, setTag] = useState('');
   const [sheetTitle, setSheetTitle] = useState('');
   const [btnText, setBtnText] = useState('');
@@ -29,27 +25,46 @@ const GroupSettingPage = () => {
 
   const handleGroupNameChange = (value: string) => {
     setGroupName(value);
-    setIsEdited(value !== dummyData.groupName);
+    setIsEdited(value !== groupSettingMockData.group.group_name);
   };
 
-  const handleExit = (name: string) => {
-    if (dummyData.isLeader && dummyData.currentUser === name) {
+  // 여기서 그룹 이름 수정 시 저장 처리
+  const handleDone = () => {
+    console.log(groupName);
+    console.log('완료');
+  };
+
+  // 그룹장인지 체크
+  const isAdmin =
+    groupSettingMockData.members.find(
+      m => m.member_id === groupSettingMockData.currentUser.member_id
+    )?.role === 'ADMIN';
+
+  // 바텀시트 문구 체크
+  const handleSheet = (member: (typeof groupSettingMockData.members)[0]) => {
+    if (isAdmin && member.member_id === groupSettingMockData.currentUser.member_id) {
       setBtnText('나갈래요');
-      setTag(dummyData.groupName);
+      setTag(groupSettingMockData.group.group_name);
       setSheetTitle(`에서 정말 나가시나요?`);
-    } else if (dummyData.isLeader) {
+    } else if (isAdmin) {
       setBtnText('내보낼래요');
-      setTag(name);
+      setTag(member.name);
       setSheetTitle(`님을 정말 내보내시나요?`);
     } else {
       setBtnText('나갈래요');
-      setTag(dummyData.groupName);
+      setTag(groupSettingMockData.group.group_name);
       setSheetTitle(`에서 정말 나가시나요?`);
     }
-    console.log(name);
     setIsOpen(true);
   };
 
+  // 멤버 방출 or 나가기 처리
+  const handleExit = () => {
+    console.log('잘있어');
+    setIsOpen(false);
+  };
+
+  // 바텀시트 닫기
   const handleClose = () => {
     setIsOpen(false);
   };
@@ -57,20 +72,24 @@ const GroupSettingPage = () => {
   return (
     <>
       <div className='fixed left-0 right-0 top-0 z-10 m-auto max-w bg-white03'>
-        <SettingHeaderContainer title='그룹 설정' isNeededDoneBtn={isEdited} />
+        <SettingHeaderContainer
+          title='그룹 설정'
+          isNeededDoneBtn={isEdited}
+          handleDone={handleDone}
+        />
       </div>
       <div className='flex flex-col gap-6 px-5 pt-20'>
         <InputWithLabel
           label='공간 이름'
           value={groupName}
-          disabled={!dummyData.isLeader}
+          disabled={!isAdmin}
           handleChange={handleGroupNameChange}
         />
         <MemberItems
-          leader={dummyData.isLeader}
-          members={dummyData.members}
-          currentUser={dummyData.currentUser}
-          handleClick={handleExit}
+          leader={isAdmin}
+          members={groupSettingMockData.members}
+          currentUser={groupSettingMockData.currentUser}
+          handleClick={handleSheet}
         />
         <InviteLinkWithLabel />
         <div className='flex flex-col gap-2'>
@@ -89,6 +108,7 @@ const GroupSettingPage = () => {
         btnText={btnText}
         isOpen={isOpen}
         setOpen={setIsOpen}
+        handleExit={handleExit}
         handleClose={handleClose}
       />
     </>


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약

> 그룹 설정 페이지

## 📌 이슈 넘버
 
> #262

## 📝 작업 내용
- 그룹 설정 페이지 더미데이터 파일 생성
- 더미데이터 불러와서 임시 처리
- MemberItem 컴포넌트 더미데이터에 맞춰 임시 타입 설정
- Header 컴포넌트 완료 버튼에 onClick 이벤트 받도록 props 설정

## 📸 스크린샷(선택)
![image](https://github.com/user-attachments/assets/59efafb6-e221-4923-a1bc-455cb93cc5f5)
![image](https://github.com/user-attachments/assets/d6ba2f87-6811-440a-b339-796b7c7ebc7e)


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
