### PR TITLE
Feature/#273-프리셋관리 화면 레이아웃 및 CSS 수정

### DIFF
--- a/src/components/common/preset/PresetItem.tsx
+++ b/src/components/common/preset/PresetItem.tsx
@@ -23,7 +23,7 @@ const PresetItem: React.FC<PresetItemProps> = ({
 }) => {
   return (
     <li
-      className={`flex flex-1 cursor-pointer list-none items-center justify-between border-b pl-5 ${
+      className={`flex flex-1 cursor-pointer list-none items-center justify-between border-b-[1px] border-solid border-white02 pl-5 ${
         isInPresetSetting ? '' : 'p-5'
       }`}
       onClick={handleSelectClick}
@@ -39,7 +39,7 @@ const PresetItem: React.FC<PresetItemProps> = ({
               삭제
             </button>
           ) : (
-            <div className='p-5'>
+            <div className='p-4 text-14'>
               <button onClick={handleSettingClick}>선택</button>
             </div>
           )}

--- a/src/components/common/tab/PresetTab/PresetTab.tsx
+++ b/src/components/common/tab/PresetTab/PresetTab.tsx
@@ -18,6 +18,7 @@ interface PresetTabProps {
   deleteButtonStates?: Record<number, boolean>;
   handleSettingClick?: (itemId: number) => void;
   handleDeleteClick?: (itemId: number) => void;
+  isBottomSheet?: boolean;
 }
 
 const PresetTab: React.FC<PresetTabProps> = ({
@@ -26,6 +27,7 @@ const PresetTab: React.FC<PresetTabProps> = ({
   deleteButtonStates = {},
   handleSettingClick,
   handleDeleteClick,
+  isBottomSheet = false,
 }) => {
   const handleClick = (item: string) => {
     console.log(item);
@@ -42,7 +44,7 @@ const PresetTab: React.FC<PresetTabProps> = ({
         <TabsContent
           key={tabData.category}
           value={tabData.category}
-          className='h-[250px] overflow-y-auto no-scrollbar'
+          className={`${isBottomSheet ? 'h-[250px]' : 'h-auto'} overflow-y-auto no-scrollbar`}
         >
           {tabData.items.map(item => (
             <div key={item.id}>

--- a/src/components/housework/HouseWorkSheet/HouseWorkSheet.tsx
+++ b/src/components/housework/HouseWorkSheet/HouseWorkSheet.tsx
@@ -30,6 +30,7 @@ const HouseWorkSheet: React.FC<HouseWorkSheetProps> = ({ isOpen, setOpen }) => {
           </div>
           <PresetTab
             data={activeTab === '사용자 정의' ? housework.userData : housework.presetData}
+            isBottomSheet={true}
           />
         </section>
         <div className='px-5'>

--- a/src/pages/PresetSettingPage.tsx
+++ b/src/pages/PresetSettingPage.tsx
@@ -36,6 +36,20 @@ const PresetSettingPage = () => {
           { id: 1, description: '매일 아침 화장실 청소하기' },
           { id: 2, description: '거실 바닥 청소하기' },
           { id: 3, description: '거실 청소기 돌리기' },
+          { id: 4, description: '거실 청소기 돌리기' },
+          { id: 5, description: '거실 청소기 돌리기' },
+          { id: 6, description: '거실 청소기 돌리기' },
+          { id: 7, description: '거실 청소기 돌리기' },
+          { id: 8, description: '거실 청소기 돌리기' },
+          { id: 9, description: '거실 청소기 돌리기' },
+          { id: 10, description: '거실 청소기 돌리기' },
+          { id: 11, description: '거실 청소기 돌리기' },
+          { id: 12, description: '거실 청소기 돌리기' },
+          { id: 13, description: '거실 청소기 돌리기' },
+          { id: 14, description: '거실 청소기 돌리기' },
+          { id: 15, description: '거실 청소기 돌리기' },
+          { id: 16, description: '거실 청소기 돌리기' },
+          { id: 17, description: '거실 청소기 돌리기' },
         ],
       },
       {
@@ -62,9 +76,9 @@ const PresetSettingPage = () => {
   };
 
   const navigate = useNavigate();
-  const [activeTab, setActiveTab] = useState<string>('사용자 정의');
+  const [activeTab, setActiveTab] = useState<string>('사용자정의');
   const chargers = Object.keys(mockData).map(key => ({
-    name: key === 'userData' ? '사용자 정의' : '프리셋',
+    name: key === 'userData' ? '사용자정의' : '프리셋',
   }));
 
   /**
@@ -72,7 +86,7 @@ const PresetSettingPage = () => {
     1: false,
     2: false,
     3: false
-  } 
+  }
   */
   const [deleteButtonStates, setDeleteButtonStates] = useState<Record<number, boolean>>({});
 
@@ -96,9 +110,11 @@ const PresetSettingPage = () => {
 
   return (
     <div className='flex min-h-screen flex-col'>
-      <Header title='프리셋 관리' isNeededDoneBtn={false} handleBack={handleBack} />
-      <Tab activeTab={activeTab} handleSetActiveTab={setActiveTab} chargers={chargers} />
-      <div className='mt-4 flex-1'>
+      <div className='sticky top-0 z-10 bg-[#fff]'>
+        <Header title='프리셋 관리' isNeededDoneBtn={false} handleBack={handleBack} />
+        <Tab activeTab={activeTab} handleSetActiveTab={setActiveTab} chargers={chargers} />
+      </div>
+      <div className='mt-5 flex-1'>
         <PresetTab
           data={activeTab === '사용자 정의' ? mockData.userData : mockData.presetData}
           isInPresetSetting={true}
@@ -107,7 +123,7 @@ const PresetSettingPage = () => {
           handleDeleteClick={handleDeleteClick}
         />
       </div>
-      <div className='bg-white sticky bottom-0'>
+      <div className='sticky bottom-0 bg-[#fff]'>
         <PresetAddInput />
       </div>
     </div>


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약

프리셋관리 화면 레이아웃 및 CSS 수정

## 📌 이슈 넘버

#273 

## 📝 작업 내용
- 프리셋 관리페이지 헤더 고정
- 프리셋아이템 border 추가
- 프리셋탭 props 추가하여 바텀시트 호출일 경우 h 고정
- 프리셋인풋 배경색 추가
- 프리셋바텀시트 props 전달 추가

## 📸 스크린샷(선택)
![image](https://github.com/user-attachments/assets/cd13dcc2-dd99-48ce-b89e-17474edc8c59)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
