### PR TITLE
Feature/#269 - 월간 통계 페이지 더미데이터 처리

### DIFF
--- a/src/components/statistics/monthly/CompletionDate/CompletionDate.tsx
+++ b/src/components/statistics/monthly/CompletionDate/CompletionDate.tsx
@@ -1,13 +1,13 @@
 interface CompletionDateProps {
-  date: string;
+  days: number;
   color?: string;
 }
 
-const CompletionDate: React.FC<CompletionDateProps> = ({ date, color = 'text-[#989393]' }) => {
+const CompletionDate: React.FC<CompletionDateProps> = ({ days, color = 'text-[#989393]' }) => {
   return (
     <div className={`flex items-center gap-2 ${color}`}>
       <i className='h-4 w-4 border border-solid border-black02'></i>
-      <p className='text-16'>{date}</p>
+      <p className='text-16'>{days}</p>
     </div>
   );
 };

--- a/src/components/statistics/monthly/MonthlyGrass/MonthlyGrass.tsx
+++ b/src/components/statistics/monthly/MonthlyGrass/MonthlyGrass.tsx
@@ -6,19 +6,26 @@ enum CompletionStatus {
   NO = 'no',
 }
 
-interface CompletionData {
+interface DailyTask {
   date: string;
+  totalTasks: number;
+  completedTasks: number;
   status: CompletionStatus;
 }
 
 interface MonthlyGrassProps {
-  completionData: CompletionData[];
+  completionData: { [key: string]: DailyTask };
+  onMonthChange: (monthKey: string) => void;
 }
 
-const MonthlyGrass: React.FC<MonthlyGrassProps> = ({ completionData }) => {
+const MonthlyGrass: React.FC<MonthlyGrassProps> = ({ completionData, onMonthChange }) => {
+  const today = new Date();
+  const firstDayCurrentMonth = new Date(today.getFullYear(), today.getMonth(), 1);
+  const lastDayPreviousMonth = new Date(firstDayCurrentMonth.getTime() - 1);
+
   const getStatus = (date: Date): CompletionStatus => {
     const dateString = date.toLocaleDateString('en-CA');
-    const dayData = completionData.find(data => data.date === dateString);
+    const dayData = completionData[dateString];
     return dayData?.status || CompletionStatus.NO;
   };
 
@@ -34,13 +41,26 @@ const MonthlyGrass: React.FC<MonthlyGrassProps> = ({ completionData }) => {
     }
   };
 
+  // TODO: 나중에 여기서 api 호출 -> 현재 달 기준으로 전과 후
+  const handleMonthChange = ({ activeStartDate }: { activeStartDate: Date | null }) => {
+    if (activeStartDate) {
+      const year = activeStartDate.getFullYear();
+      const month = String(activeStartDate.getMonth() + 1).padStart(2, '0');
+      const monthKey = `${year}-${month}`;
+      onMonthChange(monthKey);
+    }
+  };
+
   return (
     <Calendar
+      defaultActiveStartDate={lastDayPreviousMonth}
+      maxDate={lastDayPreviousMonth}
       tileClassName={getTileClassName}
       view='month'
       locale='ko'
       minDetail='month'
       maxDetail='month'
+      onActiveStartDateChange={handleMonthChange}
       navigationLabel={({ date }) => `${date.getFullYear()}년 ${date.getMonth() + 1}월`}
       formatDay={(_locale, date) => date.getDate().toString()}
     />

--- a/src/mock/monthlyGoodBad.ts
+++ b/src/mock/monthlyGoodBad.ts
@@ -1,0 +1,10 @@
+export const monthlyGoodBad = {
+  good: {
+    member: '꼼시',
+    count: '23',
+  },
+  bad: {
+    member: '꼼사',
+    count: '18',
+  },
+};

--- a/src/mock/monthlyGrassData.ts
+++ b/src/mock/monthlyGrassData.ts
@@ -1,0 +1,204 @@
+export enum CompletionStatus {
+  DONE = 'done', // 전부 완료
+  SOSO = 'soso', // 일부 완료
+  NO = 'no', // 미완료
+}
+
+export interface DailyTask {
+  date: string;
+  totalTasks: number; // 그날의 전체 할 일 개수
+  completedTasks: number; // 완료한 일의 개수
+  status: CompletionStatus;
+}
+
+export interface MonthlyStatistics {
+  dates: { [key: string]: DailyTask };
+  monthlyStats: {
+    [key: string]: {
+      // YYYY-MM 형식의 키
+      completionRate: number;
+      completedDays: number;
+    };
+  };
+}
+
+export const monthlyGrassData: MonthlyStatistics = {
+  dates: {
+    '2024-08-01': {
+      date: '2024-08-01',
+      totalTasks: 4,
+      completedTasks: 4,
+      status: CompletionStatus.DONE,
+    },
+    '2024-09-01': {
+      date: '2024-09-01',
+      totalTasks: 3,
+      completedTasks: 3,
+      status: CompletionStatus.DONE,
+    },
+    '2024-10-01': {
+      date: '2024-10-01',
+      totalTasks: 5,
+      completedTasks: 5,
+      status: CompletionStatus.DONE,
+    },
+    '2024-10-02': {
+      date: '2024-10-02',
+      totalTasks: 3,
+      completedTasks: 3,
+      status: CompletionStatus.DONE,
+    },
+    '2024-10-03': {
+      date: '2024-10-03',
+      totalTasks: 4,
+      completedTasks: 4,
+      status: CompletionStatus.DONE,
+    },
+    '2024-10-04': {
+      date: '2024-10-04',
+      totalTasks: 6,
+      completedTasks: 6,
+      status: CompletionStatus.DONE,
+    },
+    '2024-10-05': {
+      date: '2024-10-05',
+      totalTasks: 4,
+      completedTasks: 4,
+      status: CompletionStatus.DONE,
+    },
+    '2024-10-06': {
+      date: '2024-10-06',
+      totalTasks: 5,
+      completedTasks: 5,
+      status: CompletionStatus.DONE,
+    },
+    '2024-10-07': {
+      date: '2024-10-07',
+      totalTasks: 4,
+      completedTasks: 2,
+      status: CompletionStatus.SOSO,
+    },
+    '2024-10-08': {
+      date: '2024-10-08',
+      totalTasks: 3,
+      completedTasks: 0,
+      status: CompletionStatus.NO,
+    },
+    '2024-10-09': {
+      date: '2024-10-09',
+      totalTasks: 5,
+      completedTasks: 3,
+      status: CompletionStatus.SOSO,
+    },
+    '2024-10-10': {
+      date: '2024-10-10',
+      totalTasks: 4,
+      completedTasks: 2,
+      status: CompletionStatus.SOSO,
+    },
+    '2024-10-11': {
+      date: '2024-10-11',
+      totalTasks: 3,
+      completedTasks: 3,
+      status: CompletionStatus.DONE,
+    },
+    '2024-10-12': {
+      date: '2024-10-12',
+      totalTasks: 5,
+      completedTasks: 5,
+      status: CompletionStatus.DONE,
+    },
+    '2024-10-13': {
+      date: '2024-10-13',
+      totalTasks: 4,
+      completedTasks: 4,
+      status: CompletionStatus.DONE,
+    },
+    '2024-10-14': {
+      date: '2024-10-14',
+      totalTasks: 6,
+      completedTasks: 6,
+      status: CompletionStatus.DONE,
+    },
+    '2024-10-15': {
+      date: '2024-10-15',
+      totalTasks: 4,
+      completedTasks: 2,
+      status: CompletionStatus.SOSO,
+    },
+    '2024-10-16': {
+      date: '2024-10-16',
+      totalTasks: 3,
+      completedTasks: 1,
+      status: CompletionStatus.SOSO,
+    },
+    '2024-10-17': {
+      date: '2024-10-17',
+      totalTasks: 5,
+      completedTasks: 5,
+      status: CompletionStatus.DONE,
+    },
+    '2024-10-18': {
+      date: '2024-10-18',
+      totalTasks: 4,
+      completedTasks: 2,
+      status: CompletionStatus.SOSO,
+    },
+    '2024-10-19': {
+      date: '2024-10-19',
+      totalTasks: 3,
+      completedTasks: 3,
+      status: CompletionStatus.DONE,
+    },
+    '2024-10-20': {
+      date: '2024-10-20',
+      totalTasks: 5,
+      completedTasks: 5,
+      status: CompletionStatus.DONE,
+    },
+    '2024-10-21': {
+      date: '2024-10-21',
+      totalTasks: 4,
+      completedTasks: 2,
+      status: CompletionStatus.SOSO,
+    },
+    '2024-10-22': {
+      date: '2024-10-22',
+      totalTasks: 3,
+      completedTasks: 3,
+      status: CompletionStatus.DONE,
+    },
+    '2024-10-23': {
+      date: '2024-10-23',
+      totalTasks: 5,
+      completedTasks: 5,
+      status: CompletionStatus.DONE,
+    },
+    '2024-10-24': {
+      date: '2024-10-24',
+      totalTasks: 4,
+      completedTasks: 4,
+      status: CompletionStatus.DONE,
+    },
+    '2024-10-25': {
+      date: '2024-10-25',
+      totalTasks: 6,
+      completedTasks: 6,
+      status: CompletionStatus.DONE,
+    },
+  },
+  monthlyStats: {
+    '2024-08': {
+      completionRate: 80,
+      completedDays: 22,
+    },
+    '2024-09': {
+      completionRate: 75,
+      completedDays: 19,
+    },
+    '2024-10': {
+      completionRate: 68,
+      completedDays: 17,
+    },
+  },
+};

--- a/src/pages/MonthlyStatisticsPage.tsx
+++ b/src/pages/MonthlyStatisticsPage.tsx
@@ -2,52 +2,27 @@ import CompletionDate from '@/components/statistics/monthly/CompletionDate/Compl
 import CompletionRate from '@/components/statistics/monthly/CompletionRate/CompletionRate';
 import MonthlyGoodBad from '@/components/statistics/monthly/MonthlyGoodBad/MonthlyGoodBad';
 import MonthlyGrass from '@/components/statistics/monthly/MonthlyGrass/MonthlyGrass';
-
-enum CompletionStatus {
-  DONE = 'done',
-  SOSO = 'soso',
-  NO = 'no',
-}
+import { monthlyGoodBad } from '@/mock/monthlyGoodBad';
+import { monthlyGrassData } from '@/mock/monthlyGrassData';
+import { useState } from 'react';
 
 const MonthlyStatisticsPage = () => {
-  const sampleCompletionData = [
-    { date: '2024-11-01', status: CompletionStatus.DONE },
-    { date: '2024-11-02', status: CompletionStatus.DONE },
-    { date: '2024-11-03', status: CompletionStatus.DONE },
-    { date: '2024-11-04', status: CompletionStatus.DONE },
-    { date: '2024-11-05', status: CompletionStatus.DONE },
-    { date: '2024-11-06', status: CompletionStatus.DONE },
-    { date: '2024-11-07', status: CompletionStatus.SOSO },
-    { date: '2024-11-07', status: CompletionStatus.NO },
-    { date: '2024-11-09', status: CompletionStatus.SOSO },
-    { date: '2024-11-10', status: CompletionStatus.SOSO },
-    { date: '2024-11-11', status: CompletionStatus.DONE },
-    { date: '2024-11-12', status: CompletionStatus.DONE },
-    { date: '2024-11-13', status: CompletionStatus.DONE },
-    { date: '2024-11-14', status: CompletionStatus.DONE },
-    { date: '2024-11-16', status: CompletionStatus.SOSO },
-    { date: '2024-11-17', status: CompletionStatus.SOSO },
-    { date: '2024-11-18', status: CompletionStatus.DONE },
-    { date: '2024-11-19', status: CompletionStatus.SOSO },
-    { date: '2024-11-20', status: CompletionStatus.DONE },
-    { date: '2024-11-21', status: CompletionStatus.DONE },
-    { date: '2024-11-23', status: CompletionStatus.SOSO },
-    { date: '2024-11-24', status: CompletionStatus.DONE },
-    { date: '2024-11-26', status: CompletionStatus.DONE },
-    { date: '2024-11-27', status: CompletionStatus.DONE },
-    { date: '2024-11-28', status: CompletionStatus.DONE },
-  ];
+  const [currentMonth, setCurrentMonth] = useState<string>('2024-10');
+
+  const handleMonthChange = (monthKey: string) => {
+    setCurrentMonth(monthKey);
+  };
 
   return (
     <div className='flex flex-col gap-5'>
-      <MonthlyGrass completionData={sampleCompletionData} />
+      <MonthlyGrass completionData={monthlyGrassData.dates} onMonthChange={handleMonthChange} />
       <div className='flex h-8 justify-between'>
-        <CompletionRate rate={80} />
-        <CompletionDate date='18' />
+        <CompletionRate rate={monthlyGrassData.monthlyStats[currentMonth]?.completionRate} />
+        <CompletionDate days={monthlyGrassData.monthlyStats[currentMonth]?.completedDays} />
       </div>
       <div className='flex gap-3'>
-        <MonthlyGoodBad type='칭찬' name='꼼시' />
-        <MonthlyGoodBad type='찌르기' name='꼼시' />
+        <MonthlyGoodBad type='칭찬' name={monthlyGoodBad.good.member} />
+        <MonthlyGoodBad type='찌르기' name={monthlyGoodBad.bad.member} />
       </div>
     </div>
   );


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약

> 월간 페이지

## 📌 이슈 넘버

> #269 

## 📝 작업 내용
- 잔디, 완료율, 완료일 더미데이터 생성
- 칭찬, 찌르기 더미데이터 생성
- 현재 달의 이전 달까지 볼 수 있게 처리
- 이전 또는 다음 달로 이동했을때 완료일, 완료율 바뀌게 처리
- (나중에 api연결시 현재 달 기준 이전, 이후 달 정보 가져오도록)

## 📸 스크린샷(선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
