### PR TITLE
Feature/#266-집안일 완료 기능 추가

### DIFF
--- a/src/components/home/HouseworkList/HouseworkList.tsx
+++ b/src/components/home/HouseworkList/HouseworkList.tsx
@@ -1,17 +1,36 @@
 import React from 'react';
-import HouseworkListItem, {
-  HouseworkListItemProps,
-} from '@/components/home/HouseworkList/HouseworkListItem/HouseworkListItem';
+import HouseworkListItem from '@/components/home/HouseworkList/HouseworkListItem/HouseworkListItem';
 
 export interface HouseworkListProps {
-  items: HouseworkListItemProps[];
+  items: {
+    id: number;
+    actionStatus: string;
+    listTitle: string;
+    charger: string;
+    time: string;
+    category: string;
+  }[];
+  handleAction: (id: number) => void;
+  handleEdit: () => void;
+  handleDelete: () => void;
 }
 
-const HouseworkList: React.FC<HouseworkListProps> = ({ items }) => {
+const HouseworkList: React.FC<HouseworkListProps> = ({
+  items,
+  handleAction,
+  handleEdit,
+  handleDelete,
+}) => {
   return (
     <div className='flex max-w flex-col gap-2 p-5'>
       {items.map(item => (
-        <HouseworkListItem key={item.id} {...item} />
+        <HouseworkListItem
+          key={item.id}
+          {...item}
+          handleAction={handleAction}
+          handleEdit={handleEdit}
+          handleDelete={handleDelete}
+        />
       ))}
     </div>
   );

--- a/src/components/home/HouseworkList/HouseworkListItem/HouseworkListItem.tsx
+++ b/src/components/home/HouseworkList/HouseworkListItem/HouseworkListItem.tsx
@@ -22,6 +22,7 @@ export interface HouseworkListItemProps
 }
 
 const HouseworkListItem: React.FC<HouseworkListItemProps> = ({
+  id,
   actionStatus,
   handleAction,
   listTitle,
@@ -35,7 +36,7 @@ const HouseworkListItem: React.FC<HouseworkListItemProps> = ({
     <li
       className={`flex list-none items-center rounded-2xl border border-solid ${actionStatus === 'complete' ? `bg-gray03` : `bg-black02`} p-5 text-white01`}
     >
-      <ListActionBtn actionStatus={actionStatus} handleAction={handleAction} />
+      <ListActionBtn actionStatus={actionStatus} handleAction={() => handleAction(id)} id={id} />
       <div className='flex w-full justify-between pl-4'>
         <div className='flex flex-col items-start justify-center gap-2'>
           <div className='flex items-center gap-2'>

--- a/src/components/home/HouseworkList/ListActionBtn/ListActionBtn.tsx
+++ b/src/components/home/HouseworkList/ListActionBtn/ListActionBtn.tsx
@@ -13,11 +13,18 @@ export interface ListActionBtnProps {
   /** 상태 */
   actionStatus: string;
   /** 액션 */
-  handleAction: () => void;
+  handleAction: (id: number) => void;
+  /** 아이디 */
+  id: number;
 }
 
-const ListActionBtn: React.FC<ListActionBtnProps> = ({ handleAction }) => {
-  return <div className='h-5 w-5 cursor-pointer border border-solid' onClick={handleAction}></div>;
+const ListActionBtn: React.FC<ListActionBtnProps> = ({ handleAction, id }) => {
+  return (
+    <div
+      className='h-5 w-5 cursor-pointer border border-solid'
+      onClick={() => handleAction(id)}
+    ></div>
+  );
 };
 
 export default ListActionBtn;

--- a/src/mock/mockHomePage.ts
+++ b/src/mock/mockHomePage.ts
@@ -1,1 +1,28 @@
 export const GROUP_OPTIONS = ['우리집', '회사', '학교'];
+
+export const DUMMY_HOUSEWORKS = [
+  {
+    id: 1,
+    actionStatus: 'incomplete',
+    listTitle: '바닥 걸레질',
+    charger: '홍길동',
+    time: '오후 8:00',
+    category: '거실',
+  },
+  {
+    id: 2,
+    actionStatus: 'incomplete',
+    listTitle: '청소',
+    charger: '김철수',
+    time: '오후 9:00',
+    category: '주방',
+  },
+  {
+    id: 3,
+    actionStatus: 'complete',
+    listTitle: '세탁기 돌리기',
+    charger: '이영희',
+    time: '오후 10:00',
+    category: '기타',
+  },
+];

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -5,192 +5,43 @@ import HouseworkList from '@/components/home/HouseworkList/HouseworkList';
 import GroupSelectSheet from '@/components/home/GroupSelectSheet/GroupSelectSheet';
 import useHomePageStore from '@/store/useHomePageStore';
 import getWeekText from '@/utils/getWeekText';
-
-export const data = [
-  {
-    id: 1,
-    actionStatus: 'incomplete',
-    handleAction: () => {
-      console.log('Action btn clicked for 바닥 걸레질');
-    },
-    listTitle: '바닥 걸레질',
-    charger: '홍길동',
-    time: '오후 8:00',
-    handleEdit: () => {
-      console.log('Edit triggered for 바닥 걸레질');
-    },
-    handleDelete: () => {
-      console.log('Delete triggered for 바닥 걸레질');
-    },
-    category: '거실',
-  },
-  {
-    id: 2,
-    actionStatus: 'incomplete',
-    handleAction: () => {
-      console.log('Action btn clicked for 주방 청소');
-    },
-    listTitle: '청소',
-    charger: '김철수',
-    time: '오후 9:00',
-    handleEdit: () => {
-      console.log('Edit triggered for 주방 청소');
-    },
-    handleDelete: () => {
-      console.log('Delete triggered for 주방 청소');
-    },
-    category: '주방',
-  },
-  {
-    id: 3,
-    actionStatus: 'complete',
-    handleAction: () => {
-      console.log('Action btn clicked for 세탁기 돌리기');
-    },
-    listTitle: '세탁기 돌리기',
-    charger: '이영희',
-    time: '오후 10:00',
-    handleEdit: () => {
-      console.log('Edit triggered for 세탁기 돌리기');
-    },
-    handleDelete: () => {
-      console.log('Delete triggered for 세탁기 돌리기');
-    },
-    category: '기타',
-  },
-  {
-    id: 4,
-    actionStatus: 'complete',
-    handleAction: () => {
-      console.log('Action btn clicked for 정리 정돈');
-    },
-    listTitle: '정리 정돈',
-    charger: '박지성',
-    time: '오후 7:00',
-    handleEdit: () => {
-      console.log('Edit triggered for 정리 정돈');
-    },
-    handleDelete: () => {
-      console.log('Delete triggered for 정리 정돈');
-    },
-    category: '침실',
-  },
-  {
-    id: 5,
-    actionStatus: 'incomplete',
-    handleAction: () => {
-      console.log('Action btn clicked for 화장실 청소');
-    },
-    listTitle: '화장실 청소',
-    charger: '최민수',
-    time: '오후 6:00',
-    handleEdit: () => {
-      console.log('Edit triggered for 화장실 청소');
-    },
-    handleDelete: () => {
-      console.log('Delete triggered for 화장실 청소');
-    },
-    category: '화장실',
-  },
-  {
-    id: 6,
-    actionStatus: 'complete',
-    handleAction: () => {
-      console.log('Action btn clicked for 정원 가꾸기');
-    },
-    listTitle: '정원 가꾸기',
-    charger: '홍길동',
-    time: '오후 5:00',
-    handleEdit: () => {
-      console.log('Edit triggered for 정원 가꾸기');
-    },
-    handleDelete: () => {
-      console.log('Delete triggered for 정원 가꾸기');
-    },
-    category: '정원',
-  },
-  {
-    id: 7,
-    actionStatus: 'incomplete',
-    handleAction: () => {
-      console.log('Action btn clicked for 쓰레기 버리기');
-    },
-    listTitle: '쓰레기 버리기',
-    charger: '김철수',
-    time: '오후 4:00',
-    handleEdit: () => {
-      console.log('Edit triggered for 쓰레기 버리기');
-    },
-    handleDelete: () => {
-      console.log('Delete triggered for 쓰레기 버리기');
-    },
-    category: '기타',
-  },
-  {
-    id: 8,
-    actionStatus: 'complete',
-    handleAction: () => {
-      console.log('Action btn clicked for 빨래 널기');
-    },
-    listTitle: '빨래 널기',
-    charger: '이영희',
-    time: '오후 3:00',
-    handleEdit: () => {
-      console.log('Edit triggered for 빨래 널기');
-    },
-    handleDelete: () => {
-      console.log('Delete triggered for 빨래 널기');
-    },
-    category: '세탁실',
-  },
-  {
-    id: 9,
-    actionStatus: 'incomplete',
-    handleAction: () => {
-      console.log('Action btn clicked for 청소기 돌리기');
-    },
-    listTitle: '청소기 돌리기',
-    charger: '박지성',
-    time: '오후 2:00',
-    handleEdit: () => {
-      console.log('Edit triggered for 청소기 돌리기');
-    },
-    handleDelete: () => {
-      console.log('Delete triggered for 청소기 돌리기');
-    },
-    category: '거실',
-  },
-  {
-    id: 10,
-    actionStatus: 'complete',
-    handleAction: () => {
-      console.log('Action btn clicked for 정리 정돈');
-    },
-    listTitle: '정리 정돈',
-    charger: '최민수',
-    time: '오후 1:00',
-    handleEdit: () => {
-      console.log('Edit triggered for 정리 정돈');
-    },
-    handleDelete: () => {
-      console.log('Delete triggered for 정리 정돈');
-    },
-    category: '침실',
-  },
-];
+import { DUMMY_HOUSEWORKS } from '@/mock/mockHomePage';
 
 const HomePage: React.FC = () => {
   const [activeTab, setActiveTab] = useState<string>('전체');
+  const [houseworkList, setHouseworkList] = useState(DUMMY_HOUSEWORKS);
   const { setWeekText } = useHomePageStore();
 
   const chargers = [
     { name: '전체' },
-    ...Array.from(new Set(data.map(item => item.charger))).map(charger => ({ name: charger })),
+    ...Array.from(new Set(DUMMY_HOUSEWORKS.map(item => item.charger))).map(charger => ({
+      name: charger,
+    })),
   ];
 
   useEffect(() => {
     setWeekText(getWeekText(new Date()));
   }, []);
+
+  const handleAction = (id: number) => {
+    setHouseworkList(
+      houseworkList.map(housework => {
+        if (housework.id === id) {
+          return {
+            ...housework,
+            actionStatus: housework.actionStatus === 'complete' ? 'incomplete' : 'complete',
+          };
+        }
+        return housework;
+      })
+    );
+  };
+  const handleEdit = () => {
+    console.log('edit');
+  };
+  const handleDelete = () => {
+    console.log('delete');
+  };
 
   return (
     <div>
@@ -201,7 +52,10 @@ const HomePage: React.FC = () => {
         chargers={chargers}
       />
       <HouseworkList
-        items={data.filter(item => item.charger === activeTab || activeTab === '전체')}
+        items={houseworkList.filter(item => item.charger === activeTab || activeTab === '전체')}
+        handleAction={handleAction}
+        handleEdit={handleEdit}
+        handleDelete={handleDelete}
       />
       <GroupSelectSheet />
     </div>


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약

> 메인(홈) 페이지 - 집안일 완료 기능 추가

## 📌 이슈 넘버

> #266 

## 📝 작업 내용
- handleAction 함수 분리 및 props 수정
- 클릭시 완료된 집안일은 미완료로 변경되고 미완료된 일은 완료 처리

## 📸 스크린샷(선택)
![image](https://github.com/user-attachments/assets/bfb724f6-c4a1-4a5e-bf5f-a396035308b2)
![image](https://github.com/user-attachments/assets/304d0403-4147-4324-a002-2101a6bf7441)


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
