### PR TITLE
Feature/#328 - 프로필 이미지 컴포넌트 props 타입 수정

### DIFF
--- a/src/components/common/profile/ProfileImg.tsx
+++ b/src/components/common/profile/ProfileImg.tsx
@@ -1,12 +1,15 @@
+import { cn } from '@/lib/utils';
+
 interface ProfileImgProps {
+  classname?: string;
   imageUrl?: string;
 }
 
-const ProfileImg: React.FC<ProfileImgProps> = ({ imageUrl = '' }) => {
+const ProfileImg: React.FC<ProfileImgProps> = ({ classname, imageUrl = '' }) => {
   // TODO 컴포넌트 역할 분리 (상태, 함수)
 
   return (
-    <div className={`relative aspect-square h-36 w-36 overflow-hidden`}>
+    <div className={cn(`relative aspect-square h-36 w-36 overflow-hidden`, classname)}>
       <div className='flex h-full w-full items-center justify-center overflow-hidden rounded-full bg-gray03'>
         {imageUrl ? (
           <img

--- a/src/pages/MyPage.tsx
+++ b/src/pages/MyPage.tsx
@@ -9,7 +9,7 @@ const MyPage = () => {
     <div>
       <AccountSetBtn />
       <div className='px-5 py-2'>
-        <ProfileImg width={20} height={20} />
+        <ProfileImg classname='w-20 h-20' />
       </div>
       <div className='flex items-center justify-between px-5 pb-3 pt-2'>
         <AccountInfo nickname='스페이스천사' account='example@example' />


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약

> 공통 - 프로필 이미지 컴포넌트

## 📌 이슈 넘버

> #328 

## 📝 작업 내용
- w, h로 값을 받아 넣으면, 동적으로 작동을 안함
- classname으로 props를 받아 추가되도록 수정

## 📸 스크린샷(선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
