### PR TITLE
Feature/#347-홈페이지 그룹별 라우팅

### DIFF
--- a/src/components/home/GroupSelectSheet/GroupOptions/GroupOption.tsx
+++ b/src/components/home/GroupSelectSheet/GroupOptions/GroupOption.tsx
@@ -1,25 +1,29 @@
 import React from 'react';
 import useHomePageStore from '@/store/useHomePageStore';
+import { Group } from '@/types/apis/groupApi';
+import { useNavigate } from 'react-router-dom';
 
 interface GroupOptionProps {
-  /** 그룹(방) 이름 */
-  groupName: string;
+  /** 그룹(방)  */
+  group: Group;
   /** 선택 여부 */
   isSelected?: boolean;
 }
 
-const GroupOption: React.FC<GroupOptionProps> = ({ groupName, isSelected }) => {
-  const { setGroupName, setIsGroupSelectSheetOpen } = useHomePageStore();
+const GroupOption: React.FC<GroupOptionProps> = ({ group, isSelected }) => {
+  const { setCurrentGroup, setIsGroupSelectSheetOpen } = useHomePageStore();
+  const navigate = useNavigate();
 
-  const handleClick = (group: string) => {
-    setGroupName(group);
+  const handleClick = (group: Group) => {
+    setCurrentGroup(group);
     setIsGroupSelectSheetOpen(false);
+    navigate(`/main/${group.channelId}`);
   };
 
   return (
-    <li className='flex cursor-pointer items-center gap-x-2' onClick={() => handleClick(groupName)}>
+    <li className='flex cursor-pointer items-center gap-x-2' onClick={() => handleClick(group)}>
       <div className={`h-6 w-6 rounded-md ${isSelected ? 'bg-black01' : 'bg-gray02'}`}></div>
-      <div className={`text-14 ${isSelected ? 'text-black01' : 'text-gray02'}`}>{groupName}</div>
+      <div className={`text-14 ${isSelected ? 'text-black01' : 'text-gray02'}`}>{group.name}</div>
     </li>
   );
 };

--- a/src/components/home/GroupSelectSheet/GroupOptions/GroupOptions.tsx
+++ b/src/components/home/GroupSelectSheet/GroupOptions/GroupOptions.tsx
@@ -8,7 +8,7 @@ const GroupOptions: React.FC = ({}) => {
   return (
     <ul className='flex flex-col gap-y-6 px-5 pb-14 pt-8'>
       {groups.map(group => (
-        <GroupOption key={group} groupName={group} />
+        <GroupOption key={group.channelId} group={group} />
       ))}
     </ul>
   );

--- a/src/components/home/HomeHeader/GroupSelectBtn/GroupSelectBtn.tsx
+++ b/src/components/home/HomeHeader/GroupSelectBtn/GroupSelectBtn.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import useHomePageStore from '@/store/useHomePageStore';
 
 const GroupSelectBtn: React.FC = ({}) => {
-  const { groupName, setIsGroupSelectSheetOpen } = useHomePageStore();
+  const { currentGroup, setIsGroupSelectSheetOpen } = useHomePageStore();
 
   return (
     <>
@@ -11,7 +11,7 @@ const GroupSelectBtn: React.FC = ({}) => {
         onClick={() => setIsGroupSelectSheetOpen(true)}
       >
         <div className='h-4 w-4 rounded-full bg-gray01'></div>
-        <div className='pl-2'>{groupName}</div>
+        <div className='pl-2'>{currentGroup.name}</div>
       </button>
     </>
   );

--- a/src/pages/GroupCreatePage.tsx
+++ b/src/pages/GroupCreatePage.tsx
@@ -9,17 +9,24 @@ import { postCreateInviteLink } from '@/services/groupSelect/postCreateInviteLin
 
 type StepType = 'roomName' | 'invite';
 
+/**
+ * todo
+ * 1. channelId를 전역으로 관리
+ */
+
 const GroupCreatePage = () => {
   const navigate = useNavigate();
   const [step, setStep] = useState<StepType>('roomName');
   const [roomName, setRoomName] = useState('');
-  const [inviteLink, setInviteLink] = useState('sadsad');
+  const [inviteLink, setInviteLink] = useState('');
+  const [channelId, setChannelId] = useState(-1);
 
   const handleNext = async () => {
     if (roomName.trim()) {
-      const createResult = await postCreateGroup(roomName);
+      const createResult = await postCreateGroup({ name: roomName });
       const createLink = await postCreateInviteLink(createResult.result.channelId);
       setInviteLink(createLink.result.inviteLink);
+      setChannelId(createResult.result.channelId);
       setStep('invite');
     }
   };
@@ -29,13 +36,7 @@ const GroupCreatePage = () => {
   };
 
   const handleSubmit = () => {
-    if (inviteLink.trim()) {
-      console.log({
-        roomName,
-        inviteLink,
-      });
-    }
-    navigate('/main');
+    navigate(`/main/${channelId}`);
   };
 
   return (

--- a/src/pages/GroupInviteReceivePage.tsx
+++ b/src/pages/GroupInviteReceivePage.tsx
@@ -3,19 +3,25 @@ import Header from '@/components/common/header/Header';
 import InputBox from '@/components/common/input/InputBox';
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { postJoinGroup } from '@/services/groupSelect/postJoinGroup';
+import { useToast } from '@/hooks/use-toast';
 
 const GroupInviteReceivePage = () => {
   const [inviteLink, setInviteLink] = useState('');
   const navigate = useNavigate();
+  const { toast } = useToast();
 
   const handleBack = () => {
     navigate('/group-select');
   };
 
-  // TODO: 백엔드랑 연결
-  const handleGoIn = () => {
-    console.log(inviteLink);
-    navigate('/main');
+  const handleGoIn = async () => {
+    try {
+      const joinResult = await postJoinGroup({ inviteLink });
+      navigate(`/main/${joinResult.result.channelId}`);
+    } catch (error) {
+      toast({ title: '에러가 발생했습니다 ㅠㅠ', description: '유효한 링크인지 확인해주세요!' });
+    }
   };
 
   return (

--- a/src/pages/GroupInviteReceivePage.tsx
+++ b/src/pages/GroupInviteReceivePage.tsx
@@ -20,7 +20,9 @@ const GroupInviteReceivePage = () => {
       const joinResult = await postJoinGroup({ inviteLink });
       navigate(`/main/${joinResult.result.channelId}`);
     } catch (error) {
-      toast({ title: '에러가 발생했습니다 ㅠㅠ', description: '유효한 링크인지 확인해주세요!' });
+      if (error instanceof Error) {
+        toast({ title: '에러가 발생했습니다 ㅠㅠ', description: error.message });
+      }
     }
   };
 

--- a/src/pages/GroupSelectPage.tsx
+++ b/src/pages/GroupSelectPage.tsx
@@ -6,6 +6,7 @@ import { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import useHomePageStore from '@/store/useHomePageStore';
 import { getMyGroup } from '@/services/groupSelect/getMyGroup';
+import { Group } from '@/types/apis/groupApi';
 
 const GroupSelectPage = () => {
   const navigate = useNavigate();
@@ -27,32 +28,32 @@ const GroupSelectPage = () => {
   const handleInvitedBtnClick = () => {
     navigate('/group/invite-receive');
   };
-  const handleClick = (group: string) => {
-    setGroupName(group);
-    navigate('/main');
+  const handleClick = (group: Group) => {
+    setGroupName(group.name);
+    navigate(`/main/${group.channelId}`);
   };
 
   return (
-    <div className='flex min-h-screen flex-col'>
+    <div className='flex flex-col min-h-screen'>
       <Logo />
       <GroupSelectTitle />
-      <div className='flex flex-1 flex-col gap-y-4 px-5 py-4'>
+      <div className='flex flex-col flex-1 px-5 py-4 gap-y-4'>
         {groups.length > 0 ? (
           groups.map(group => (
             <OpenSheetBtn
               key={group.channelId}
               text={group.name}
-              handleClick={() => handleClick(group.name)}
+              handleClick={() => handleClick(group)}
               type='groupSelect'
             />
           ))
         ) : (
-          <div className='flex flex-1 items-center justify-center whitespace-pre-line text-center text-gray03'>
+          <div className='flex items-center justify-center flex-1 text-center whitespace-pre-line text-gray03'>
             {'현재 방이 없어요\n새로운 방을 만들어보세요'}
           </div>
         )}
       </div>
-      <div className='flex gap-x-4 px-5 pt-6'>
+      <div className='flex px-5 pt-6 gap-x-4'>
         <Button
           label='방만들기'
           variant='full'

--- a/src/pages/GroupSelectPage.tsx
+++ b/src/pages/GroupSelectPage.tsx
@@ -10,12 +10,11 @@ import { Group } from '@/types/apis/groupApi';
 
 const GroupSelectPage = () => {
   const navigate = useNavigate();
-  const { setGroupName, groups, setGroups } = useHomePageStore();
+  const { setCurrentGroup, groups, setGroups } = useHomePageStore();
 
   useEffect(() => {
     const fetchMyGroup = async () => {
       const groups = await getMyGroup();
-      console.log(groups.result.channelList);
       setGroups(groups.result.channelList);
     };
 
@@ -29,15 +28,15 @@ const GroupSelectPage = () => {
     navigate('/group/invite-receive');
   };
   const handleClick = (group: Group) => {
-    setGroupName(group.name);
+    setCurrentGroup(group);
     navigate(`/main/${group.channelId}`);
   };
 
   return (
-    <div className='flex flex-col min-h-screen'>
+    <div className='flex min-h-screen flex-col'>
       <Logo />
       <GroupSelectTitle />
-      <div className='flex flex-col flex-1 px-5 py-4 gap-y-4'>
+      <div className='flex flex-1 flex-col gap-y-4 px-5 py-4'>
         {groups.length > 0 ? (
           groups.map(group => (
             <OpenSheetBtn
@@ -48,12 +47,12 @@ const GroupSelectPage = () => {
             />
           ))
         ) : (
-          <div className='flex items-center justify-center flex-1 text-center whitespace-pre-line text-gray03'>
+          <div className='flex flex-1 items-center justify-center whitespace-pre-line text-center text-gray03'>
             {'현재 방이 없어요\n새로운 방을 만들어보세요'}
           </div>
         )}
       </div>
-      <div className='flex px-5 pt-6 gap-x-4'>
+      <div className='flex gap-x-4 px-5 pt-6'>
         <Button
           label='방만들기'
           variant='full'

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -6,11 +6,14 @@ import GroupSelectSheet from '@/components/home/GroupSelectSheet/GroupSelectShee
 import useHomePageStore from '@/store/useHomePageStore';
 import getWeekText from '@/utils/getWeekText';
 import { DUMMY_HOUSEWORKS } from '@/mock/mockHomePage';
+import { useParams } from 'react-router-dom';
+import { getMyGroup } from '@/services/groupSelect/getMyGroup';
 
 const HomePage: React.FC = () => {
   const [activeTab, setActiveTab] = useState<string>('전체');
   const [houseworkList, setHouseworkList] = useState(DUMMY_HOUSEWORKS);
-  const { setWeekText } = useHomePageStore();
+  const { setWeekText, setCurrentGroup, setGroups } = useHomePageStore();
+  const { channelId } = useParams();
 
   const chargers = [
     { name: '전체' },
@@ -20,7 +23,18 @@ const HomePage: React.FC = () => {
   ];
 
   useEffect(() => {
+    const fetchMyGroups = async () => {
+      const getMyGroupResult = await getMyGroup();
+      const myGroups = getMyGroupResult.result.channelList;
+      setGroups(myGroups);
+      if (channelId) {
+        const currentGroup = myGroups.find(group => group.channelId === Number(channelId));
+        setCurrentGroup(currentGroup!);
+      }
+    };
+
     setWeekText(getWeekText(new Date()));
+    fetchMyGroups();
   }, []);
 
   const handleAction = (id: number) => {

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -85,7 +85,7 @@ export const router = createBrowserRouter([
         element: <GroupInviteReceivePage />,
       },
       {
-        path: '/main',
+        path: '/main/:channelId',
         element: <MainLayout />,
         children: [
           {

--- a/src/services/groupSelect/postCreateGroup.ts
+++ b/src/services/groupSelect/postCreateGroup.ts
@@ -1,12 +1,11 @@
 import { axiosInstance } from '@/services/axiosInstance';
-import { CreateGroupRes } from '@/types/apis/groupApi';
+import { CreateGroupReq, CreateGroupRes } from '@/types/apis/groupApi';
 
-export const postCreateGroup = async (name: string) => {
+export const postCreateGroup = async ({ name }: CreateGroupReq) => {
   try {
-    const response = await axiosInstance.post<CreateGroupRes>('/api/v1/channels', { name: name });
+    const response = await axiosInstance.post<CreateGroupRes>('/api/v1/channels', { name });
     return response.data;
   } catch (error) {
-    console.error('채널 생성 실패:', error);
-    throw error;
+    throw new Error();
   }
 };

--- a/src/services/groupSelect/postJoinGroup.ts
+++ b/src/services/groupSelect/postJoinGroup.ts
@@ -6,7 +6,6 @@ export const postJoinGroup = async ({ inviteLink }: JoinGroupReq) => {
     const response = await axiosInstance.post<JoinGroupRes>(`/api/v1/channels/join/${inviteLink}`);
     return response.data;
   } catch (error) {
-    console.error('방 입장 실패:', error);
-    throw error;
+    throw new Error('유효한 링크인지 확인해주세요!');
   }
 };

--- a/src/services/groupSelect/postJoinGroup.ts
+++ b/src/services/groupSelect/postJoinGroup.ts
@@ -1,7 +1,7 @@
 import { axiosInstance } from '@/services/axiosInstance';
 import { JoinGroupReq, JoinGroupRes } from '@/types/apis/groupApi';
 
-export const postJoinGroup = async (inviteLink: JoinGroupReq) => {
+export const postJoinGroup = async ({ inviteLink }: JoinGroupReq) => {
   try {
     const response = await axiosInstance.post<JoinGroupRes>(`/api/v1/channels/join/${inviteLink}`);
     return response.data;

--- a/src/store/useHomePageStore.ts
+++ b/src/store/useHomePageStore.ts
@@ -2,8 +2,8 @@ import { create } from 'zustand';
 import { Group } from '@/types/apis/groupApi';
 
 interface HomePageState {
-  groupName: string;
-  setGroupName: (groupName: string) => void;
+  currentGroup: Group;
+  setCurrentGroup: (group: Group) => void;
 
   isGroupSelectSheetOpen: boolean;
   setIsGroupSelectSheetOpen: (isOpen: boolean) => void;
@@ -16,8 +16,8 @@ interface HomePageState {
 }
 
 const useHomePageStore = create<HomePageState>(set => ({
-  groupName: '기본 그룹명',
-  setGroupName: name => set({ groupName: name }),
+  currentGroup: { channelId: 0, name: '기본 그룹명' },
+  setCurrentGroup: group => set({ currentGroup: group }),
 
   isGroupSelectSheetOpen: false,
   setIsGroupSelectSheetOpen: isOpen => set({ isGroupSelectSheetOpen: isOpen }),


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약

> 홈페이지 - 그룹별 라우팅으로 구분

## 📌 이슈 넘버

- #263 
- #347 

## 📝 작업 내용
- groupName을 사용하던 모든 컴포넌트 group으로 수정
- 홈 헤더에서 그룹을 클릭해서 전환시 해당 그룹으로 라우팅
- 방(그룹) 선택 페이지에서 그룹을 선택하면 해당 그룹으로 라우팅
- 새로고침시 현재 참가하고 있는 방으로 자동으로 전역 상태 설정
- 새로고침시 내가 속한 그룹 전역 상태 설정

## 📸 스크린샷(선택)
![image](https://github.com/user-attachments/assets/125fb613-3a1c-45f0-8aa6-400a7c6fd404)


## 💬리뷰 요구사항(선택)

> 수정할 사항 있으면 말씀해주세요!
