### PR TITLE
Feature/#350-방(그룹)별 인원 패치

### DIFF
--- a/src/components/home/WeeklyDate/WeeklyDate.tsx
+++ b/src/components/home/WeeklyDate/WeeklyDate.tsx
@@ -65,7 +65,7 @@ const WeeklyDate = () => {
               {currWeek.map((week, idx) => (
                 <DateItem
                   key={idx}
-                  date={week.date.split('.')[2]}
+                  date={week.date.split('-')[2]}
                   day={week.day}
                   pendingCnt={0}
                   isActive={activeDate === week.date && current === i}

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -15,13 +15,7 @@ const HomePage: React.FC = () => {
   const [houseworkList, setHouseworkList] = useState(DUMMY_HOUSEWORKS);
   const { setWeekText, setCurrentGroup, setGroups } = useHomePageStore();
   const { channelId } = useParams();
-
-  const chargers = [
-    { name: '전체' },
-    ...Array.from(new Set(DUMMY_HOUSEWORKS.map(item => item.charger))).map(charger => ({
-      name: charger,
-    })),
-  ];
+  const [chargers, setChargers] = useState<{ name: string }[]>([{ name: '전체' }]);
 
   useEffect(() => {
     const fetchMyGroups = async () => {
@@ -34,17 +28,25 @@ const HomePage: React.FC = () => {
       }
     };
 
+    setWeekText(getWeekText(new Date()));
+    fetchMyGroups();
+  }, []);
+
+  useEffect(() => {
     const fetchGroupUsers = async () => {
       if (!channelId) return;
       const newChannelId = Number(channelId);
       const getGroupUsersResult = await getGroupUser({ channelId: newChannelId });
-      console.log(getGroupUsersResult);
+      const newChargers = [
+        { name: '전체' },
+        ...Array.from(new Set(getGroupUsersResult.result.userList.map(user => user.nickName))).map(
+          charger => ({ name: charger })
+        ),
+      ];
+      setChargers(newChargers);
     };
-
-    setWeekText(getWeekText(new Date()));
-    fetchMyGroups();
     fetchGroupUsers();
-  }, []);
+  }, [channelId]);
 
   const handleAction = (id: number) => {
     setHouseworkList(

--- a/src/utils/getFormattedDate.ts
+++ b/src/utils/getFormattedDate.ts
@@ -7,5 +7,5 @@ export default function getFormattedDate(date: Date): string {
   const year = date.getFullYear();
   const month = String(date.getMonth() + 1).padStart(2, '0'); // 월은 0부터 시작하므로 +1
   const day = String(date.getDate()).padStart(2, '0'); // 일자가 한 자리 수일 경우 앞에 0 추가
-  return `${year}. ${month}. ${day}.`;
+  return `${year}-${month}-${day}`;
 }

--- a/src/utils/getWeekDates.ts
+++ b/src/utils/getWeekDates.ts
@@ -1,5 +1,5 @@
 export interface WeekDates {
-  date: string;
+  date: string; // 'YYYY-MM-DD' 형식으로 변경
   day: string;
 }
 
@@ -18,12 +18,13 @@ export default function getWeekDates(date: Date): WeekDates[] {
     const currentDate = new Date(startOfWeek);
     currentDate.setDate(startOfWeek.getDate() + i);
 
-    const options: Intl.DateTimeFormatOptions = {
-      year: 'numeric',
-      month: '2-digit',
-      day: '2-digit',
-    };
-    const formattedDate = currentDate.toLocaleDateString('ko-KR', options);
+    // YYYY-MM-DD 형식으로 변환
+    const year = currentDate.getFullYear();
+    const month = String(currentDate.getMonth() + 1).padStart(2, '0'); // 0~11을 1~12로
+    const day = String(currentDate.getDate()).padStart(2, '0');
+
+    // YYYY-MM-DD 형식으로 날짜 생성
+    const formattedDate = `${year}-${month}-${day}`;
     const dayName = daysShort[i]; // 축약된 요일 사용
 
     weekDates.push({ date: formattedDate, day: dayName });


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약

> 메인(홈) 페이지 - 방(그룹)별 인월 패치 

## 📌 이슈 넘버

- #263 
- #350 

## 📝 작업 내용
- 그룹 변경시 해당 그룹에 참가하고있는 멤버 패치
- 날짜 yyyy-mm-dd 형식으로 변환

## 📸 스크린샷(선택)
![image](https://github.com/user-attachments/assets/f63423db-ced0-49e7-a210-149960238a78)


## 💬리뷰 요구사항(선택)

> 수정할 사항 있으면 말씀해주세요!