### PR TITLE
Feature/#278-사용자정의 탭 > 프리셋 카테고리 생성 & 조회 기능 구현

### DIFF
--- a/src/components/housework/HouseWorkSheet/HouseWorkSheet.tsx
+++ b/src/components/housework/HouseWorkSheet/HouseWorkSheet.tsx
@@ -6,7 +6,7 @@ import Tab from '@/components/common/tab/Tab/Tab';
 import useAddHouseWorkStore from '@/store/useAddHouseWorkStore';
 import { mockData } from '@/mock/mockPresetSettingPage';
 import { PresetDefault, PresetTabName } from '@/constants';
-import { convertTabNameToChargers } from '@/utils/ConvertUtils';
+import { convertTabNameToChargers } from '@/utils/convertUtils';
 
 interface HouseWorkSheetProps {
   /** 바텀시트 오픈 여부 */
@@ -16,7 +16,7 @@ interface HouseWorkSheetProps {
 }
 
 const HouseWorkSheet: React.FC<HouseWorkSheetProps> = ({ isOpen, setOpen }) => {
-  const [activeTab, setActiveTab] = useState<string>(PresetTabName.USER_DATA);
+  const [activeTab, setActiveTab] = useState<string>(PresetTabName.PRESET_DATA);
   const [selectedHouseWork, setSelectedHouseWork] = useState<string | null>(null);
   const [selectedCategory, setSelectedCategory] = useState<string | null>(null);
   const [selectedItem, setSelectedItem] = useState<number | null>(null);

--- a/src/components/setting/presetSetting/PresetAddInput.tsx
+++ b/src/components/setting/presetSetting/PresetAddInput.tsx
@@ -1,9 +1,15 @@
 import PresetCategory from '@/components/setting/presetSetting/PresetCategory';
 import React, { useState } from 'react';
 
-interface PresetAddInputProps {}
+interface Category {
+  presetCategoryId: number;
+  category: string;
+}
+interface PresetAddInputProps {
+  categoryList: Category[];
+}
 
-const PresetAddInput: React.FC<PresetAddInputProps> = ({}) => {
+const PresetAddInput: React.FC<PresetAddInputProps> = ({ categoryList }) => {
   const [activeCate, setActiveCate] = useState('거실');
 
   const handleCateClick = (cate: string) => {
@@ -11,7 +17,11 @@ const PresetAddInput: React.FC<PresetAddInputProps> = ({}) => {
   };
   return (
     <div className='rounded-t-2xl pb-2 pt-4 shadow-[0_-4px_6px_-1px_rgba(0,0,0,0.1)]'>
-      <PresetCategory activeCate={activeCate} handleCateClick={handleCateClick} />
+      <PresetCategory
+        categoryList={categoryList}
+        activeCate={activeCate}
+        handleCateClick={handleCateClick}
+      />
       <input className='w-full p-5 focus:outline-none' placeholder='집안일을 입력해주세요' />
     </div>
   );

--- a/src/components/setting/presetSetting/PresetCategory.tsx
+++ b/src/components/setting/presetSetting/PresetCategory.tsx
@@ -1,21 +1,29 @@
 import React from 'react';
 
+interface Category {
+  presetCategoryId: number;
+  category: string;
+}
 interface PresetCategoryProps {
   activeCate: string;
   handleCateClick: (cate: string) => void;
+  categoryList: Category[];
 }
 
-const PresetCategory: React.FC<PresetCategoryProps> = ({ activeCate, handleCateClick }) => {
-  const category = ['거실', '주방', '욕실', '침실', '기타'];
+const PresetCategory: React.FC<PresetCategoryProps> = ({
+  activeCate,
+  handleCateClick,
+  categoryList,
+}) => {
   return (
     <div className='flex px-5'>
-      {category.map(cate => (
+      {categoryList.map(item => (
         <button
-          key={cate}
-          className={`pr-4 text-14 ${activeCate === cate ? 'text-black01' : 'text-gray03'}`}
-          onClick={() => handleCateClick(cate)}
+          key={item.presetCategoryId}
+          className={`pr-4 text-14 ${activeCate === item.category ? 'text-black01' : 'text-gray03'}`}
+          onClick={() => handleCateClick(item.category)}
         >
-          {cate}
+          {item.category}
         </button>
       ))}
     </div>

--- a/src/constants/TabName.ts
+++ b/src/constants/TabName.ts
@@ -1,4 +1,4 @@
 export const PresetTabName = {
-  USER_DATA: '사용자정의',
   PRESET_DATA: '프리셋',
+  USER_DATA: '사용자정의',
 };

--- a/src/hooks/usePresetSetting.ts
+++ b/src/hooks/usePresetSetting.ts
@@ -1,0 +1,57 @@
+import { useEffect } from 'react';
+import { getAllCategoryName, postCreateCategory } from '@/services/setting/preset';
+import { Category } from '@/constants';
+import usePresetSettingStore from '@/store/usePresetSettingStore';
+
+const usePresetSetting = (channelId: number) => {
+  const { setCategoryList } = usePresetSettingStore();
+
+  useEffect(() => {
+    let ignore = false;
+
+    // TODO
+    // 고정 카테고리값을 여기서 생성하는것이 불필요한 과정이라서,
+    // 백엔드측에 기본 고정값을 그룹생성 시점에 넣어달라고 요청한 상태
+    // 수정이 완료된다면, create 호출문 제거하고 service/ 폴더에서도 미사용 문구 넣어주기
+    const initCategories = async () => {
+      try {
+        const response = await getAllCategoryName({ channelId });
+        const categoryListData = response.result.categoryList;
+
+        if (!ignore) {
+          if (categoryListData.length === 0) {
+            const CategoryWithoutAll = Object.values(Category).filter(
+              value => value !== Category.ALL
+            );
+
+            await Promise.all(
+              CategoryWithoutAll.map(categoryName =>
+                postCreateCategory({
+                  channelId,
+                  category: categoryName,
+                })
+              )
+            );
+
+            const newResponse = await getAllCategoryName({ channelId });
+            if (!ignore) {
+              setCategoryList(newResponse.result.categoryList);
+            }
+          } else {
+            setCategoryList(categoryListData);
+          }
+        }
+      } catch (error) {
+        console.error('카테고리 초기화 오류:', error);
+      }
+    };
+
+    initCategories();
+
+    return () => {
+      ignore = true;
+    };
+  }, [channelId, setCategoryList]);
+};
+
+export default usePresetSetting;

--- a/src/pages/PresetSettingPage.tsx
+++ b/src/pages/PresetSettingPage.tsx
@@ -7,12 +7,21 @@ import { useNavigate } from 'react-router-dom';
 import { mockData } from '@/mock/mockPresetSettingPage';
 import { PresetDefault, PresetTabName } from '@/constants';
 import { convertTabNameToChargers } from '@/utils/convertUtils';
+import usePresetSetting from '@/hooks/usePresetSetting';
+import usePresetSettingStore from '@/store/usePresetSettingStore';
+import useHomePageStore from '@/store/useHomePageStore';
 
 const PresetSettingPage = () => {
   const navigate = useNavigate();
-  const [activeTab, setActiveTab] = useState<string>(PresetTabName.USER_DATA);
+  const [activeTab, setActiveTab] = useState<string>(PresetTabName.PRESET_DATA);
   const [deleteButtonStates, setDeleteButtonStates] = useState<Record<number, boolean>>({});
+  const { categoryList } = usePresetSettingStore();
 
+  const { currentGroup } = useHomePageStore();
+  const channelId = currentGroup.channelId;
+  usePresetSetting(channelId);
+
+  // TODO HOOK으로 이동
   const handleSettingClick = (itemId: number) => {
     setDeleteButtonStates(prev => ({
       ...prev,
@@ -55,7 +64,7 @@ const PresetSettingPage = () => {
         />
       </div>
       <div className='sticky bottom-0 bg-[#fff]'>
-        <PresetAddInput />
+        <PresetAddInput categoryList={categoryList} />
       </div>
     </div>
   );

--- a/src/services/setting/preset/getAllCategoryName.ts
+++ b/src/services/setting/preset/getAllCategoryName.ts
@@ -3,12 +3,12 @@ import { GetAllPresetCategoryReq, GetAllPresetCategoryRes } from '@/types/apis/p
 import { GetPageParams } from '@/types/apis/pageApi';
 
 export const getAllCategoryName = async (
-  data: GetAllPresetCategoryReq,
+  { channelId }: GetAllPresetCategoryReq,
   params: GetPageParams = { page: 0, size: 20 }
 ) => {
   try {
     const response = await axiosInstance.get<GetAllPresetCategoryRes>(
-      `/api/v1/channels/${data.channelId}/presets/categories/names`,
+      `/api/v1/channels/${channelId}/presets/categories/names`,
       { params }
     );
     return response.data;

--- a/src/services/setting/preset/index.ts
+++ b/src/services/setting/preset/index.ts
@@ -1,0 +1,7 @@
+export { deleteCategory } from '@/services/setting/preset/deleteCategory';
+export { deletePresetItem } from '@/services/setting/preset/deletePresetItem';
+export { getAllCategoryList } from '@/services/setting/preset/getAllCategoryList';
+export { getAllCategoryName } from '@/services/setting/preset/getAllCategoryName';
+export { getSingleCategoryList } from '@/services/setting/preset/getSingleCategoryList';
+export { postCreateCategory } from '@/services/setting/preset/postCreateCategory';
+export { postCreatePresetItem } from '@/services/setting/preset/postCreatePresetItem';

--- a/src/services/setting/preset/postCreateCategory.ts
+++ b/src/services/setting/preset/postCreateCategory.ts
@@ -1,11 +1,11 @@
 import { axiosInstance } from '@/services/axiosInstance';
 import { CreatePresetCategoryReq, CreatePresetCategoryRes } from '@/types/apis/presetApi';
 
-export const postCreateCategory = async (data: CreatePresetCategoryReq) => {
+export const postCreateCategory = async ({ channelId, category }: CreatePresetCategoryReq) => {
   try {
     const response = await axiosInstance.post<CreatePresetCategoryRes>(
-      `/api/v1/channels/${data.channelId}/presets/categories`,
-      data.category
+      `/api/v1/channels/${channelId}/presets/categories`,
+      { category }
     );
     return response.data;
   } catch (error) {

--- a/src/store/usePresetSettingStore.ts
+++ b/src/store/usePresetSettingStore.ts
@@ -1,0 +1,18 @@
+import { create } from 'zustand';
+
+interface Category {
+  presetCategoryId: number;
+  category: string;
+}
+
+interface PresetState {
+  categoryList: Category[];
+  setCategoryList: (categories: Category[]) => void;
+}
+
+const usePresetSettingStore = create<PresetState>(set => ({
+  categoryList: [],
+  setCategoryList: categoryList => set({ categoryList }),
+}));
+
+export default usePresetSettingStore;


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약

- 사용자정의 탭 > 프리셋 카테고리 생성 & 조회 기능 구현

## 📌 이슈 넘버

- #278 

## 📝 작업 내용
- 사용자정의 탭 > 프리셋 카테고리 생성 & 조회 기능 구현
ㄴ 백엔드 수정완료되면 생성 기능은 제거할 예정
- 프리셋 api 매개변수 수정
- 프리셋 탭 (사용자정의/프리셋) 순서 변경

## 📸 스크린샷(선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
