### PR TITLE
Feature/#310-사용자정의 탭 > 프리셋 아이템 추가 기능 구현 & 리팩토링

### DIFF
--- a/src/components/common/preset/PresetItem.tsx
+++ b/src/components/common/preset/PresetItem.tsx
@@ -6,27 +6,29 @@ import React from 'react';
 export interface PresetItemProps extends HouseworkCategoryTagProps {
   housework: string;
   handleSelectClick?: () => void;
-  isInPresetSetting?: boolean;
+  isPresetSettingCustom?: boolean;
   isShowDeleteBtn?: boolean;
   handleSettingClick?: () => void;
   handleDeleteClick?: () => void;
   isSelected?: boolean;
+  isBottomSheet?: boolean;
 }
 
 const PresetItem: React.FC<PresetItemProps> = ({
   category,
   housework,
   handleSelectClick,
-  isInPresetSetting,
+  isPresetSettingCustom,
   isShowDeleteBtn,
   handleSettingClick,
   handleDeleteClick,
   isSelected,
+  isBottomSheet,
 }) => {
   return (
     <li
       className={`flex flex-1 cursor-pointer list-none items-center justify-between border-b-[1px] border-solid border-white02 pl-5 ${
-        isInPresetSetting ? '' : 'p-5'
+        isBottomSheet ? 'p-5' : 'p-4'
       }`}
       onClick={handleSelectClick}
     >
@@ -34,14 +36,14 @@ const PresetItem: React.FC<PresetItemProps> = ({
         <HouseworkCategoryTag category={category} isSelected={isSelected} />
         <p className='pl-4 text-14'>{housework}</p>
       </div>
-      {isInPresetSetting && (
+      {isPresetSettingCustom && (
         <div className='flex items-center'>
           {isShowDeleteBtn ? (
-            <button className='bg-gray03 p-4 text-14' onClick={handleDeleteClick}>
+            <button className='bg-gray03 text-14' onClick={handleDeleteClick}>
               삭제
             </button>
           ) : (
-            <div className='p-4 text-14'>
+            <div className='text-14'>
               <button onClick={handleSettingClick}>선택</button>
             </div>
           )}

--- a/src/components/common/tab/PresetTab/PresetTab.tsx
+++ b/src/components/common/tab/PresetTab/PresetTab.tsx
@@ -1,7 +1,7 @@
 import PresetItem from '@/components/common/preset/PresetItem';
 import PresetTabItem from '@/components/common/tab/PresetTab/PresetTabItem';
 import { Tabs, TabsContent, TabsList } from '@/components/common/ui/tabs';
-import { Category as PresetCategory } from '@/constants/Category';
+import { Category as PresetCategory } from '@/constants/category';
 
 interface PresetItem {
   id: number;
@@ -15,7 +15,7 @@ interface PresetData {
 
 interface PresetTabProps {
   data: PresetData[];
-  isInPresetSetting?: boolean;
+  isPresetSettingCustom?: boolean;
   deleteButtonStates?: Record<number, boolean>;
   handleSettingClick?: (itemId: number) => void;
   handleDeleteClick?: (itemId: number) => void;
@@ -26,7 +26,7 @@ interface PresetTabProps {
 
 const PresetTab: React.FC<PresetTabProps> = ({
   data,
-  isInPresetSetting = false,
+  isPresetSettingCustom = false,
   deleteButtonStates = {},
   handleSettingClick,
   handleDeleteClick,
@@ -62,7 +62,8 @@ const PresetTab: React.FC<PresetTabProps> = ({
               handleSelectClick={() =>
                 handleClick && handleClick(item.id, item.description, item.category)
               }
-              isInPresetSetting={isInPresetSetting}
+              isBottomSheet={isBottomSheet}
+              isPresetSettingCustom={isPresetSettingCustom}
               isShowDeleteBtn={deleteButtonStates[item.id]} //각 아이템의 boolean값이 들어간다.
               handleSettingClick={handleSettingClick && (() => handleSettingClick(item.id))}
               handleDeleteClick={handleDeleteClick && (() => handleDeleteClick(item.id))}
@@ -86,7 +87,8 @@ const PresetTab: React.FC<PresetTabProps> = ({
                 handleSelectClick={() =>
                   handleClick && handleClick(item.id, item.description, tabData.category)
                 }
-                isInPresetSetting={isInPresetSetting}
+                isBottomSheet={isBottomSheet}
+                isPresetSettingCustom={isPresetSettingCustom}
                 isShowDeleteBtn={deleteButtonStates[item.id]} //각 아이템의 boolean값이 들어간다.
                 handleSettingClick={handleSettingClick && (() => handleSettingClick(item.id))}
                 handleDeleteClick={handleDeleteClick && (() => handleDeleteClick(item.id))}

--- a/src/components/setting/presetSetting/PresetAddInput.tsx
+++ b/src/components/setting/presetSetting/PresetAddInput.tsx
@@ -1,5 +1,7 @@
 import PresetCategory from '@/components/setting/presetSetting/PresetCategory';
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
+import { Category } from '@/constants';
+import usePresetSettingStore from '@/store/usePresetSettingStore';
 
 interface Category {
   presetCategoryId: number;
@@ -7,22 +9,51 @@ interface Category {
 }
 interface PresetAddInputProps {
   categoryList: Category[];
+  handleAddInput: (inputVal: string, categoryId: number) => void;
 }
 
-const PresetAddInput: React.FC<PresetAddInputProps> = ({ categoryList }) => {
-  const [activeCate, setActiveCate] = useState('거실');
+const PresetAddInput: React.FC<PresetAddInputProps> = ({ categoryList, handleAddInput }) => {
+  const {
+    inputVal,
+    setInputVal,
+    activeInputCate,
+    setActiveInputCate,
+    activeInputCateId,
+    setActiveInputCateId,
+  } = usePresetSettingStore();
 
-  const handleCateClick = (cate: string) => {
-    setActiveCate(cate);
+  // 첫번째 카테고리 활성화
+  useEffect(() => {
+    setActiveInputCate(categoryList[0].category);
+    setActiveInputCateId(categoryList[0].presetCategoryId);
+  }, [categoryList, setActiveInputCate, setActiveInputCateId]);
+
+  const handleInputCateClick = (cate: string, cateId: number) => {
+    setActiveInputCate(cate);
+    setActiveInputCateId(cateId);
   };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter' && inputVal.trim()) {
+      handleAddInput(inputVal, activeInputCateId);
+      setInputVal('');
+    }
+  };
+
   return (
     <div className='rounded-t-2xl pb-2 pt-4 shadow-[0_-4px_6px_-1px_rgba(0,0,0,0.1)]'>
       <PresetCategory
         categoryList={categoryList}
-        activeCate={activeCate}
-        handleCateClick={handleCateClick}
+        activeCate={activeInputCate}
+        handleCateClick={handleInputCateClick}
       />
-      <input className='w-full p-5 focus:outline-none' placeholder='집안일을 입력해주세요' />
+      <input
+        className='w-full p-5 focus:outline-none'
+        placeholder='집안일을 입력해주세요'
+        value={inputVal}
+        onChange={e => setInputVal(e.target.value)}
+        onKeyDown={handleKeyDown}
+      />
     </div>
   );
 };

--- a/src/components/setting/presetSetting/PresetCategory.tsx
+++ b/src/components/setting/presetSetting/PresetCategory.tsx
@@ -6,7 +6,7 @@ interface Category {
 }
 interface PresetCategoryProps {
   activeCate: string;
-  handleCateClick: (cate: string) => void;
+  handleCateClick: (cate: string, categoryId: number) => void;
   categoryList: Category[];
 }
 
@@ -21,7 +21,7 @@ const PresetCategory: React.FC<PresetCategoryProps> = ({
         <button
           key={item.presetCategoryId}
           className={`pr-4 text-14 ${activeCate === item.category ? 'text-black01' : 'text-gray03'}`}
-          onClick={() => handleCateClick(item.category)}
+          onClick={() => handleCateClick(item.category, item.presetCategoryId)}
         >
           {item.category}
         </button>

--- a/src/constants/PresetDefault.ts
+++ b/src/constants/PresetDefault.ts
@@ -1,4 +1,4 @@
-import { Category } from '@/constants/Category';
+import { Category } from '@/constants/category';
 
 export const PresetDefault = [
   {

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,6 +1,6 @@
-export { Category } from '@/constants/Category';
-export { PresetDefault } from '@/constants/PresetDefault';
-export { PresetTabName } from '@/constants/TabName';
+export { Category } from '@/constants/category';
+export { PresetDefault } from '@/constants/presetDefault';
+export { PresetTabName } from '@/constants/tabName';
 export {
   DUMMY_QUESTION_STEP1,
   DUMMY_QUESTION_STEP2,

--- a/src/hooks/usePresetSetting.ts
+++ b/src/hooks/usePresetSetting.ts
@@ -1,10 +1,21 @@
 import { useEffect } from 'react';
-import { getAllCategoryName, postCreateCategory } from '@/services/setting/preset';
+import {
+  getAllCategoryName,
+  postCreateCategory,
+  postCreatePresetItem,
+} from '@/services/setting/preset';
 import { Category } from '@/constants';
 import usePresetSettingStore from '@/store/usePresetSettingStore';
+import { useNavigate } from 'react-router-dom';
+import { mockData } from '@/mock/mockPresetSettingPage';
+import { PresetDefault, PresetTabName } from '@/constants';
+import useHomePageStore from '@/store/useHomePageStore';
 
-const usePresetSetting = (channelId: number) => {
-  const { setCategoryList } = usePresetSettingStore();
+const usePresetSetting = () => {
+  const navigate = useNavigate();
+  const { setCategoryList, setDeleteButtonStates, activeTab } = usePresetSettingStore();
+  const { currentGroup } = useHomePageStore();
+  const channelId = currentGroup.channelId;
 
   useEffect(() => {
     let ignore = false;
@@ -42,7 +53,7 @@ const usePresetSetting = (channelId: number) => {
           }
         }
       } catch (error) {
-        console.error('카테고리 초기화 오류:', error);
+        console.error('카테고리 초기화 오류: ', error);
       }
     };
 
@@ -52,6 +63,49 @@ const usePresetSetting = (channelId: number) => {
       ignore = true;
     };
   }, [channelId, setCategoryList]);
+
+  const handleAddInput = async (name: string, presetCategoryId: number) => {
+    try {
+      const response = await postCreatePresetItem({
+        channelId,
+        presetCategoryId,
+        name,
+      });
+      console.log(response);
+    } catch (error) {
+      console.error('프리셋 아이템 추가 오류: ', error);
+    }
+  };
+
+  const handleSettingClick = (itemId: number) => {
+    setDeleteButtonStates(prev => ({
+      ...prev,
+      [itemId]: true,
+    }));
+  };
+
+  const handleDeleteClick = (itemId: number) => {
+    setDeleteButtonStates(prev => ({
+      ...prev,
+      [itemId]: false,
+    }));
+  };
+
+  const handleBack = () => {
+    navigate(-1);
+  };
+
+  const getPresetData = () => {
+    return activeTab === PresetTabName.USER_DATA ? mockData.userData : PresetDefault;
+  };
+
+  return {
+    handleAddInput,
+    handleSettingClick,
+    handleDeleteClick,
+    handleBack,
+    getPresetData,
+  };
 };
 
 export default usePresetSetting;

--- a/src/pages/PresetSettingPage.tsx
+++ b/src/pages/PresetSettingPage.tsx
@@ -2,47 +2,15 @@ import Header from '@/components/common/header/Header';
 import PresetTab from '@/components/common/tab/PresetTab/PresetTab';
 import Tab from '@/components/common/tab/Tab/Tab';
 import PresetAddInput from '@/components/setting/presetSetting/PresetAddInput';
-import { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
-import { mockData } from '@/mock/mockPresetSettingPage';
-import { PresetDefault, PresetTabName } from '@/constants';
+import { PresetTabName } from '@/constants';
 import { convertTabNameToChargers } from '@/utils/convertUtils';
 import usePresetSetting from '@/hooks/usePresetSetting';
 import usePresetSettingStore from '@/store/usePresetSettingStore';
-import useHomePageStore from '@/store/useHomePageStore';
 
 const PresetSettingPage = () => {
-  const navigate = useNavigate();
-  const [activeTab, setActiveTab] = useState<string>(PresetTabName.PRESET_DATA);
-  const [deleteButtonStates, setDeleteButtonStates] = useState<Record<number, boolean>>({});
-  const { categoryList } = usePresetSettingStore();
-
-  const { currentGroup } = useHomePageStore();
-  const channelId = currentGroup.channelId;
-  usePresetSetting(channelId);
-
-  // TODO HOOK으로 이동
-  const handleSettingClick = (itemId: number) => {
-    setDeleteButtonStates(prev => ({
-      ...prev,
-      [itemId]: true,
-    }));
-  };
-
-  const handleDeleteClick = (itemId: number) => {
-    setDeleteButtonStates(prev => ({
-      ...prev,
-      [itemId]: false,
-    }));
-  };
-
-  const handleBack = () => {
-    navigate(-1);
-  };
-
-  const getPresetData = () => {
-    return activeTab === PresetTabName.USER_DATA ? mockData.userData : PresetDefault;
-  };
+  const { categoryList, activeTab, setActiveTab, deleteButtonStates } = usePresetSettingStore();
+  const { handleAddInput, handleSettingClick, handleDeleteClick, handleBack, getPresetData } =
+    usePresetSetting();
 
   return (
     <div className='flex min-h-screen flex-col'>
@@ -54,18 +22,26 @@ const PresetSettingPage = () => {
           chargers={convertTabNameToChargers(PresetTabName)}
         />
       </div>
-      <div className='mt-5 flex-1'>
-        <PresetTab
-          data={getPresetData()}
-          isInPresetSetting={true}
-          deleteButtonStates={deleteButtonStates}
-          handleSettingClick={handleSettingClick}
-          handleDeleteClick={handleDeleteClick}
-        />
-      </div>
-      <div className='sticky bottom-0 bg-[#fff]'>
-        <PresetAddInput categoryList={categoryList} />
-      </div>
+      {activeTab === PresetTabName.USER_DATA ? (
+        <>
+          <div className='mt-5 flex-1'>
+            <PresetTab
+              data={getPresetData()}
+              isPresetSettingCustom={true}
+              deleteButtonStates={deleteButtonStates}
+              handleSettingClick={handleSettingClick}
+              handleDeleteClick={handleDeleteClick}
+            />
+          </div>
+          <div className='sticky bottom-0 bg-[#fff]'>
+            <PresetAddInput categoryList={categoryList} handleAddInput={handleAddInput} />
+          </div>
+        </>
+      ) : (
+        <div className='mt-5 flex-1'>
+          <PresetTab data={getPresetData()} isPresetSettingCustom={false} />
+        </div>
+      )}
     </div>
   );
 };

--- a/src/services/setting/preset/postCreatePresetItem.ts
+++ b/src/services/setting/preset/postCreatePresetItem.ts
@@ -1,11 +1,15 @@
 import { axiosInstance } from '@/services/axiosInstance';
 import { CreatePresetItemReq, CreatePresetItemRes } from './../../../types/apis/presetApi';
 
-export const postCreatePresetItem = async (data: CreatePresetItemReq) => {
+export const postCreatePresetItem = async ({
+  channelId,
+  presetCategoryId,
+  name,
+}: CreatePresetItemReq) => {
   try {
     const response = await axiosInstance.post<CreatePresetItemRes>(
-      `/api/v1/channels/${data.channelId}/presets/categories/${data.presetCategoryId}/items`,
-      data.name
+      `/api/v1/channels/${channelId}/presets/categories/${presetCategoryId}/items`,
+      { name }
     );
     return response.data;
   } catch (error) {

--- a/src/store/usePresetSettingStore.ts
+++ b/src/store/usePresetSettingStore.ts
@@ -1,4 +1,5 @@
 import { create } from 'zustand';
+import { Category, PresetTabName } from '@/constants';
 
 interface Category {
   presetCategoryId: number;
@@ -6,13 +7,46 @@ interface Category {
 }
 
 interface PresetState {
+  // 카테고리 리스트
   categoryList: Category[];
   setCategoryList: (categories: Category[]) => void;
+  // 활성화 탭 (사용자정의 | 프리셋)
+  activeTab: string;
+  setActiveTab: (activeTab: string | ((prevState: string) => string)) => void;
+  // input 값
+  inputVal: string;
+  setInputVal: (inputVal: string) => void;
+  // input 활성화 카테고리
+  activeInputCate: string;
+  setActiveInputCate: (activeInputTab: string) => void;
+  // input 활성화 카테고리 id
+  activeInputCateId: number;
+  setActiveInputCateId: (activeInputTabId: number) => void;
+  // 삭제버튼
+  deleteButtonStates: Record<number, boolean>;
+  setDeleteButtonStates: (
+    updateFn: (prevState: Record<number, boolean>) => Record<number, boolean>
+  ) => void;
 }
 
 const usePresetSettingStore = create<PresetState>(set => ({
   categoryList: [],
   setCategoryList: categoryList => set({ categoryList }),
+  activeTab: PresetTabName.PRESET_DATA,
+  // TODO 공통 Tab컴포넌트 Props 타입을 맞추기위함으로 불필요하다면 Tab컴포넌트 Props 변경필요
+  setActiveTab: activeTab =>
+    set(state => ({
+      activeTab: typeof activeTab === 'function' ? activeTab(state.activeTab) : activeTab,
+    })),
+  inputVal: '',
+  setInputVal: inputVal => set({ inputVal }),
+  activeInputCate: '',
+  setActiveInputCate: activeInputCate => set({ activeInputCate }),
+  activeInputCateId: 0,
+  setActiveInputCateId: activeInputCateId => set({ activeInputCateId }),
+  deleteButtonStates: {},
+  setDeleteButtonStates: updateFn =>
+    set(state => ({ deleteButtonStates: updateFn(state.deleteButtonStates) })),
 }));
 
 export default usePresetSettingStore;


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약

- 사용자정의 탭 > 프리셋 아이템 추가 기능 구현 & 리팩토링

## 📌 이슈 넘버

- #310 

## 📝 작업 내용
- 사용자정의 탭 > 아이템 생성 기능 구현
- 프리셋 설정 페이지 코드 리팩토링
ㄴ page 에서 호출하는 서비스로직 hook 으로 분리
ㄴ page 에서 사용하던 state 들 zustand store 로 이동
- 프리셋 탭에서는 input 박스, 삭제버튼 미노출 처리

## 📸 스크린샷(선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
