### PR TITLE
Feature/#311-사용자정의 탭 > 프리셋 아이템 삭제 기능 구현

### DIFF
--- a/src/hooks/usePresetSetting.ts
+++ b/src/hooks/usePresetSetting.ts
@@ -1,5 +1,6 @@
 import { useEffect } from 'react';
 import {
+  deletePresetItem,
   getAllCategoryName,
   postCreateCategory,
   postCreatePresetItem,
@@ -66,12 +67,11 @@ const usePresetSetting = () => {
 
   const handleAddInput = async (name: string, presetCategoryId: number) => {
     try {
-      const response = await postCreatePresetItem({
+      await postCreatePresetItem({
         channelId,
         presetCategoryId,
         name,
       });
-      console.log(response);
     } catch (error) {
       console.error('프리셋 아이템 추가 오류: ', error);
     }
@@ -84,11 +84,17 @@ const usePresetSetting = () => {
     }));
   };
 
-  const handleDeleteClick = (itemId: number) => {
+  const handleDeleteClick = async (presetItemId: number) => {
     setDeleteButtonStates(prev => ({
       ...prev,
-      [itemId]: false,
+      [presetItemId]: false,
     }));
+
+    try {
+      await deletePresetItem({ channelId, presetItemId });
+    } catch (error) {
+      console.error('프리셋 아이템 삭제 오류: ', error);
+    }
   };
 
   const handleBack = () => {


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약

- 사용자정의 탭 > 프리셋 아이템 삭제 기능 구현

## 📌 이슈 넘버

- #311 

## 📝 작업 내용
- 사용자정의 탭 > 프리셋 아이템 삭제 기능 구현

## 📸 스크린샷(선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
