### PR TITLE
Feature/#276-사용자정의 탭 > 프리셋 리스트 조회 기능 구현

### DIFF
--- a/src/components/common/tab/PresetTab/PresetTab.tsx
+++ b/src/components/common/tab/PresetTab/PresetTab.tsx
@@ -4,17 +4,22 @@ import { Tabs, TabsContent, TabsList } from '@/components/common/ui/tabs';
 import { Category as PresetCategory } from '@/constants/category';
 
 interface PresetItem {
-  id: number;
-  description: string;
+  // 프리셋 아이템 아이디
+  presetItemId: number;
+  // 프리셋 아이템 이름
+  name: string;
 }
-
-interface PresetData {
+interface PresetList {
+  // 프리셋 카테고리 아이디
+  presetCategoryId: number;
+  // 프리셋 카테고리 이름
   category: string;
-  items: PresetItem[];
+  // 프리셋 아이템 리스트
+  presetItemList: Array<PresetItem>;
 }
 
 interface PresetTabProps {
-  data: PresetData[];
+  presetData: PresetList[];
   isPresetSettingCustom?: boolean;
   deleteButtonStates?: Record<number, boolean>;
   handleSettingClick?: (itemId: number) => void;
@@ -25,7 +30,7 @@ interface PresetTabProps {
 }
 
 const PresetTab: React.FC<PresetTabProps> = ({
-  data,
+  presetData,
   isPresetSettingCustom = false,
   deleteButtonStates = {},
   handleSettingClick,
@@ -36,8 +41,8 @@ const PresetTab: React.FC<PresetTabProps> = ({
 }) => {
   const allPresetData = {
     category: PresetCategory.ALL,
-    items: data.flatMap(category =>
-      category.items.map(item => ({ ...item, category: category.category }))
+    items: presetData.flatMap(categoryList =>
+      categoryList.presetItemList.map(item => ({ ...item, category: categoryList.category }))
     ),
   };
 
@@ -45,8 +50,13 @@ const PresetTab: React.FC<PresetTabProps> = ({
     <Tabs defaultValue={PresetCategory.ALL}>
       <TabsList className='flex w-full justify-start gap-4 overflow-x-auto overflow-y-hidden bg-white03 p-0 px-5 no-scrollbar'>
         <PresetTabItem name={allPresetData.category} value={allPresetData.category} icon='' />
-        {data.map((tab, index) => (
-          <PresetTabItem key={index} name={tab.category} value={tab.category} icon='' />
+        {presetData.map(categoryList => (
+          <PresetTabItem
+            key={categoryList.presetCategoryId}
+            name={categoryList.category}
+            value={categoryList.category}
+            icon=''
+          />
         ))}
       </TabsList>
       <TabsContent
@@ -55,44 +65,50 @@ const PresetTab: React.FC<PresetTabProps> = ({
         className={`${isBottomSheet ? 'h-[250px]' : 'h-auto'} overflow-y-auto no-scrollbar`}
       >
         {allPresetData.items.map(item => (
-          <div key={item.id}>
+          <div key={item.presetItemId}>
             <PresetItem
               category={item.category}
-              housework={item.description}
+              housework={item.name}
               handleSelectClick={() =>
-                handleClick && handleClick(item.id, item.description, item.category)
+                handleClick && handleClick(item.presetItemId, item.name, item.category)
               }
               isBottomSheet={isBottomSheet}
               isPresetSettingCustom={isPresetSettingCustom}
-              isShowDeleteBtn={deleteButtonStates[item.id]} //각 아이템의 boolean값이 들어간다.
-              handleSettingClick={handleSettingClick && (() => handleSettingClick(item.id))}
-              handleDeleteClick={handleDeleteClick && (() => handleDeleteClick(item.id))}
-              isSelected={selectedItem === item.id}
+              isShowDeleteBtn={deleteButtonStates[item.presetItemId]} //각 아이템의 boolean값이 들어간다.
+              handleSettingClick={
+                handleSettingClick && (() => handleSettingClick(item.presetItemId))
+              }
+              handleDeleteClick={handleDeleteClick && (() => handleDeleteClick(item.presetItemId))}
+              isSelected={selectedItem === item.presetItemId}
             />
           </div>
         ))}
       </TabsContent>
 
-      {data.map(tabData => (
+      {presetData.map(categoryList => (
         <TabsContent
-          key={tabData.category}
-          value={tabData.category}
+          key={categoryList.presetCategoryId}
+          value={categoryList.category}
           className={`${isBottomSheet ? 'h-[250px]' : 'h-auto'} overflow-y-auto no-scrollbar`}
         >
-          {tabData.items.map(item => (
-            <div key={item.id}>
+          {categoryList.presetItemList.map(item => (
+            <div key={item.presetItemId}>
               <PresetItem
-                category={tabData.category}
-                housework={item.description}
+                category={categoryList.category}
+                housework={item.name}
                 handleSelectClick={() =>
-                  handleClick && handleClick(item.id, item.description, tabData.category)
+                  handleClick && handleClick(item.presetItemId, item.name, categoryList.category)
                 }
                 isBottomSheet={isBottomSheet}
                 isPresetSettingCustom={isPresetSettingCustom}
-                isShowDeleteBtn={deleteButtonStates[item.id]} //각 아이템의 boolean값이 들어간다.
-                handleSettingClick={handleSettingClick && (() => handleSettingClick(item.id))}
-                handleDeleteClick={handleDeleteClick && (() => handleDeleteClick(item.id))}
-                isSelected={selectedItem === item.id}
+                isShowDeleteBtn={deleteButtonStates[item.presetItemId]} //각 아이템의 boolean값이 들어간다.
+                handleSettingClick={
+                  handleSettingClick && (() => handleSettingClick(item.presetItemId))
+                }
+                handleDeleteClick={
+                  handleDeleteClick && (() => handleDeleteClick(item.presetItemId))
+                }
+                isSelected={selectedItem === item.presetItemId}
               />
             </div>
           ))}

--- a/src/constants/PresetDefault.ts
+++ b/src/constants/PresetDefault.ts
@@ -1,63 +1,83 @@
 import { Category } from '@/constants/category';
 
-export const PresetDefault = [
+interface PresetItem {
+  // 프리셋 아이템 아이디
+  presetItemId: number;
+  // 프리셋 아이템 이름
+  name: string;
+}
+interface PresetList {
+  // 프리셋 카테고리 아이디
+  presetCategoryId: number;
+  // 프리셋 카테고리 이름
+  category: string;
+  // 프리셋 아이템 리스트
+  presetItemList: Array<PresetItem>;
+}
+
+export const PresetDefault: PresetList[] = [
   {
+    presetCategoryId: 1,
     category: Category.LIVING_ROOM,
-    items: [
-      { id: 101, description: '정리정돈' },
-      { id: 102, description: '쓰레기통 비우기' },
-      { id: 103, description: '먼지 닦기' },
-      { id: 104, description: '진공청소기 돌리기' },
-      { id: 105, description: '바닥 걸레질' },
-      { id: 106, description: '창문 청소' },
-      { id: 107, description: '카펫 및 러그 청소' },
+    presetItemList: [
+      { presetItemId: 101, name: '정리정돈' },
+      { presetItemId: 102, name: '쓰레기통 비우기' },
+      { presetItemId: 103, name: '먼지 닦기' },
+      { presetItemId: 104, name: '진공청소기 돌리기' },
+      { presetItemId: 105, name: '바닥 걸레질' },
+      { presetItemId: 106, name: '창문 청소' },
+      { presetItemId: 107, name: '카펫 및 러그 청소' },
     ],
   },
   {
+    presetCategoryId: 2,
     category: Category.BED_ROOM,
-    items: [
-      { id: 201, description: '침구 정리' },
-      { id: 202, description: '진공청소기 돌리기' },
-      { id: 203, description: '바닥 걸레질' },
-      { id: 204, description: '침구 교체' },
-      { id: 205, description: '옷장 정리' },
-      { id: 206, description: '창문 청소' },
-      { id: 207, description: '매트리스 청소' },
+    presetItemList: [
+      { presetItemId: 201, name: '침구 정리' },
+      { presetItemId: 202, name: '진공청소기 돌리기' },
+      { presetItemId: 203, name: '바닥 걸레질' },
+      { presetItemId: 204, name: '침구 교체' },
+      { presetItemId: 205, name: '옷장 정리' },
+      { presetItemId: 206, name: '창문 청소' },
+      { presetItemId: 207, name: '매트리스 청소' },
     ],
   },
   {
+    presetCategoryId: 3,
     category: Category.KITCHEN,
-    items: [
-      { id: 301, description: '설거지' },
-      { id: 302, description: '조리대 및 싱크대 닦기' },
-      { id: 303, description: '쓰레기통 비우기' },
-      { id: 304, description: '냉장고 정리' },
-      { id: 305, description: '오븐 및 전자레인지 청소' },
-      { id: 306, description: '바닥 진공청소기 및 걸레질' },
-      { id: 307, description: '찬장 및 서랍 정리' },
-      { id: 308, description: '환풍기 필터 청소' },
+    presetItemList: [
+      { presetItemId: 301, name: '설거지' },
+      { presetItemId: 302, name: '조리대 및 싱크대 닦기' },
+      { presetItemId: 303, name: '쓰레기통 비우기' },
+      { presetItemId: 304, name: '냉장고 정리' },
+      { presetItemId: 305, name: '오븐 및 전자레인지 청소' },
+      { presetItemId: 306, name: '바닥 진공청소기 및 걸레질' },
+      { presetItemId: 307, name: '찬장 및 서랍 정리' },
+      { presetItemId: 308, name: '환풍기 필터 청소' },
     ],
   },
   {
+    presetCategoryId: 4,
     category: Category.BATH_ROOM,
-    items: [
-      { id: 401, description: '세면대 및 거울 닦기' },
-      { id: 402, description: '변기 청소' },
-      { id: 403, description: '샤워기 및 욕조 물기 닦기' },
-      { id: 404, description: '바닥 및 타일 청소' },
-      { id: 405, description: '샤워 커튼 및 욕조 청소' },
-      { id: 406, description: '휴지통 비우기' },
-      { id: 407, description: '배수구 청소' },
-      { id: 408, description: '환풍기 필터 청소' },
+    presetItemList: [
+      { presetItemId: 401, name: '세면대 및 거울 닦기' },
+      { presetItemId: 402, name: '변기 청소' },
+      { presetItemId: 403, name: '샤워기 및 욕조 물기 닦기' },
+      { presetItemId: 404, name: '바닥 및 타일 청소' },
+      { presetItemId: 405, name: '샤워 커튼 및 욕조 청소' },
+      { presetItemId: 406, name: '휴지통 비우기' },
+      { presetItemId: 407, name: '배수구 청소' },
+      { presetItemId: 408, name: '환풍기 필터 청소' },
     ],
   },
   {
+    presetCategoryId: 5,
     category: Category.ETC,
-    items: [
-      { id: 501, description: '쓰레기 분리수거' },
-      { id: 502, description: '강아지 산책' },
-      { id: 503, description: '화분 물 주기' },
-      { id: 504, description: '자동차 세차' },
+    presetItemList: [
+      { presetItemId: 501, name: '쓰레기 분리수거' },
+      { presetItemId: 502, name: '강아지 산책' },
+      { presetItemId: 503, name: '화분 물 주기' },
+      { presetItemId: 504, name: '자동차 세차' },
     ],
   },
 ];

--- a/src/hooks/usePresetSetting.ts
+++ b/src/hooks/usePresetSetting.ts
@@ -3,16 +3,17 @@ import {
   deletePresetItem,
   getAllCategoryName,
   postCreatePresetItem,
+  getAllCategoryList,
 } from '@/services/setting/preset';
 import usePresetSettingStore from '@/store/usePresetSettingStore';
 import { useNavigate } from 'react-router-dom';
-import { mockData } from '@/mock/mockPresetSettingPage';
 import { PresetDefault, PresetTabName } from '@/constants';
 import useHomePageStore from '@/store/useHomePageStore';
 
 const usePresetSetting = () => {
   const navigate = useNavigate();
-  const { setCategoryList, setDeleteButtonStates, activeTab } = usePresetSettingStore();
+  const { setCategoryList, setDeleteButtonStates, activeTab, setPresetData } =
+    usePresetSettingStore();
   const { currentGroup } = useHomePageStore();
   const channelId = currentGroup.channelId;
 
@@ -30,6 +31,24 @@ const usePresetSetting = () => {
     }
   };
 
+  useEffect(() => {
+    getPresetData();
+  }, [activeTab]);
+
+  const getPresetData = async () => {
+    setPresetData([]);
+    if (activeTab === PresetTabName.USER_DATA) {
+      try {
+        const response = await getAllCategoryList({ channelId });
+        setPresetData(response.result.presetCategoryList);
+      } catch (error) {
+        console.error('프리셋 리스트 조회 오류: ', error);
+      }
+    } else {
+      setPresetData(PresetDefault);
+    }
+  };
+
   const handleAddInput = async (name: string, presetCategoryId: number) => {
     try {
       await postCreatePresetItem({
@@ -37,6 +56,8 @@ const usePresetSetting = () => {
         presetCategoryId,
         name,
       });
+      // 업데이트된 아이템 리스트 조회
+      await getPresetData();
     } catch (error) {
       console.error('프리셋 아이템 추가 오류: ', error);
     }
@@ -57,6 +78,8 @@ const usePresetSetting = () => {
 
     try {
       await deletePresetItem({ channelId, presetItemId });
+      // 업데이트된 아이템 리스트 조회
+      await getPresetData();
     } catch (error) {
       console.error('프리셋 아이템 삭제 오류: ', error);
     }
@@ -66,16 +89,11 @@ const usePresetSetting = () => {
     navigate(-1);
   };
 
-  const getPresetData = () => {
-    return activeTab === PresetTabName.USER_DATA ? mockData.userData : PresetDefault;
-  };
-
   return {
     handleAddInput,
     handleSettingClick,
     handleDeleteClick,
     handleBack,
-    getPresetData,
   };
 };
 

--- a/src/pages/PresetSettingPage.tsx
+++ b/src/pages/PresetSettingPage.tsx
@@ -8,9 +8,9 @@ import usePresetSetting from '@/hooks/usePresetSetting';
 import usePresetSettingStore from '@/store/usePresetSettingStore';
 
 const PresetSettingPage = () => {
-  const { categoryList, activeTab, setActiveTab, deleteButtonStates } = usePresetSettingStore();
-  const { handleAddInput, handleSettingClick, handleDeleteClick, handleBack, getPresetData } =
-    usePresetSetting();
+  const { categoryList, activeTab, setActiveTab, deleteButtonStates, presetData } =
+    usePresetSettingStore();
+  const { handleAddInput, handleSettingClick, handleDeleteClick, handleBack } = usePresetSetting();
 
   return (
     <div className='flex min-h-screen flex-col'>
@@ -26,7 +26,7 @@ const PresetSettingPage = () => {
         <>
           <div className='mt-5 flex-1'>
             <PresetTab
-              data={getPresetData()}
+              presetData={presetData}
               isPresetSettingCustom={true}
               deleteButtonStates={deleteButtonStates}
               handleSettingClick={handleSettingClick}
@@ -39,7 +39,7 @@ const PresetSettingPage = () => {
         </>
       ) : (
         <div className='mt-5 flex-1'>
-          <PresetTab data={getPresetData()} isPresetSettingCustom={false} />
+          <PresetTab presetData={presetData} isPresetSettingCustom={false} />
         </div>
       )}
     </div>

--- a/src/services/setting/preset/getAllCategoryKeywordList.ts
+++ b/src/services/setting/preset/getAllCategoryKeywordList.ts
@@ -1,0 +1,20 @@
+import { axiosInstance } from '@/services/axiosInstance';
+import { GetAllPresetKeywordListReq, GetAllPresetKeywordListRes } from '@/types/apis/presetApi';
+import { GetPageParams } from '@/types/apis/pageApi';
+
+// 현재 호출부 없음
+export const getAllCategoryKeywordList = async (
+  data: GetAllPresetKeywordListReq,
+  params: GetPageParams = { page: 0, size: 20 }
+) => {
+  try {
+    const response = await axiosInstance.get<GetAllPresetKeywordListRes>(
+      `/api/v1/channels/${data.channelId}/presets/keywords`,
+      { params }
+    );
+    return response.data;
+  } catch (error) {
+    console.error('프리셋 전체 키워드 리스트 조회 실패:', error);
+    throw error;
+  }
+};

--- a/src/services/setting/preset/getAllCategoryList.ts
+++ b/src/services/setting/preset/getAllCategoryList.ts
@@ -8,7 +8,7 @@ export const getAllCategoryList = async (
 ) => {
   try {
     const response = await axiosInstance.get<GetAllPresetListRes>(
-      `/api/v1/channels/${data.channelId}/presets/keywords`,
+      `/api/v1/channels/${data.channelId}/presets/categories/items`,
       { params }
     );
     return response.data;

--- a/src/services/setting/preset/index.ts
+++ b/src/services/setting/preset/index.ts
@@ -1,6 +1,7 @@
 export { deleteCategory } from '@/services/setting/preset/deleteCategory';
 export { deletePresetItem } from '@/services/setting/preset/deletePresetItem';
 export { getAllCategoryList } from '@/services/setting/preset/getAllCategoryList';
+export { getAllCategoryKeywordList } from '@/services/setting/preset/getAllCategoryKeywordList';
 export { getAllCategoryName } from '@/services/setting/preset/getAllCategoryName';
 export { getSingleCategoryList } from '@/services/setting/preset/getSingleCategoryList';
 export { postCreateCategory } from '@/services/setting/preset/postCreateCategory';

--- a/src/store/usePresetSettingStore.ts
+++ b/src/store/usePresetSettingStore.ts
@@ -2,8 +2,20 @@ import { create } from 'zustand';
 import { Category, PresetTabName } from '@/constants';
 
 interface Category {
+  // 프리셋 카테고리 아이디
   presetCategoryId: number;
+  // 프리셋 카테고리 이름
   category: string;
+}
+
+interface PresetItem {
+  // 프리셋 아이템 아이디
+  presetItemId: number;
+  // 프리셋 아이템 이름
+  name: string;
+}
+interface PresetList extends Category {
+  presetItemList: Array<PresetItem>;
 }
 
 interface PresetState {
@@ -27,6 +39,9 @@ interface PresetState {
   setDeleteButtonStates: (
     updateFn: (prevState: Record<number, boolean>) => Record<number, boolean>
   ) => void;
+  // 프리셋 리스트 데이터
+  presetData: PresetList[];
+  setPresetData: (presetData: PresetList[]) => void;
 }
 
 const usePresetSettingStore = create<PresetState>(set => ({
@@ -47,6 +62,8 @@ const usePresetSettingStore = create<PresetState>(set => ({
   deleteButtonStates: {},
   setDeleteButtonStates: updateFn =>
     set(state => ({ deleteButtonStates: updateFn(state.deleteButtonStates) })),
+  presetData: [],
+  setPresetData: (presetData: PresetList[]) => set({ presetData }),
 }));
 
 export default usePresetSettingStore;

--- a/src/types/apis/presetApi.ts
+++ b/src/types/apis/presetApi.ts
@@ -40,8 +40,8 @@ export interface GetAllPresetCategoryRes extends BaseRes {
   };
 }
 
-/** 프리셋 리스트 정보 */
-export interface PresetList {
+/** 프리셋 키워드 리스트 정보 */
+export interface PresetKeywordList {
   /** 프리셋 카테고리 아이디 */
   presetCategoryId: number;
   /** 프리셋 카테고리 이름 */
@@ -55,11 +55,11 @@ export interface PresetList {
 }
 
 /** 전체 프리셋 키워드(카테고리-아이템) 리스트 조회 */
-export interface GetAllPresetListReq extends Pick<Common, 'channelId'> {}
-export interface GetAllPresetListRes extends BaseRes {
+export interface GetAllPresetKeywordListReq extends Pick<Common, 'channelId'> {}
+export interface GetAllPresetKeywordListRes extends BaseRes {
   result: {
     /** 프리셋 키워드(카테고리-아이템) 리스트 */
-    presetKeywordList: Array<PresetList>;
+    presetKeywordList: Array<PresetKeywordList>;
   };
 }
 
@@ -68,8 +68,7 @@ export interface PresetItem {
   /** 프리셋 아이템 아이디 */
   presetItemId: number;
   /** 프리셋 아이템 이름 */
-  // TODO 백엔드 키값 수정되면 여기도 수정 'name'
-  value: string;
+  name: string;
 }
 
 /** 특정 프리셋 카테고리의 프리셋 아이템 리스트 조회 */
@@ -115,5 +114,22 @@ export interface DeletePresetItemRes extends BaseRes {
   result: {
     /** 프리셋 아이템 아이디 */
     presetItemId: number;
+  };
+}
+
+/** 프리셋 리스트 정보 */
+export interface PresetList {
+  /** 프리셋 카테고리 아이디 */
+  presetCategoryId: number;
+  /** 프리셋 카테고리 이름 */
+  category: string;
+  presetItemList: Array<PresetItem>;
+}
+
+/** 전체 프리셋 카테고리와 해당 아이템 리스트 조회 */
+export interface GetAllPresetListReq extends Pick<Common, 'channelId'> {}
+export interface GetAllPresetListRes extends BaseRes {
+  result: {
+    presetCategoryList: Array<PresetList>;
   };
 }


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약

- 사용자정의 탭 > 프리셋 리스트 조회 기능 구현

## 📌 이슈 넘버

- #276 
- #277 

## 📝 작업 내용
- 사용자정의 탭 > 프리셋 리스트 조회 기능 구현
- 전체 리스트&아이템 리스트 조회 api 추가
- api req 에 맞게 구조, 네이밍 변경

## 📸 스크린샷(선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
