### PR TITLE
Feature/#376-집안일 삭제 기능 추가

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,10 +1,15 @@
 import { router } from '@/router';
 import { RouterProvider } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+const queryClient = new QueryClient();
 
 function App() {
   return (
     <>
-      <RouterProvider router={router} />
+      <QueryClientProvider client={queryClient}>
+        <RouterProvider router={router} />
+      </QueryClientProvider>
     </>
   );
 }

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -12,12 +12,7 @@ import { PAGE_SIZE } from '@/constants/common';
 import { getHouseworks } from '@/services/housework/getHouseworks';
 import { deleteHousework } from '@/services/housework/deleteHouswork';
 import { useQuery } from '@tanstack/react-query';
-
-/**
- * todo
- * 무한 스크롤 구현
- * housework는 전역 상태가 아니라 리액트 쿼리로 관리?
- */
+import { useToast } from '@/hooks/use-toast';
 
 const HomePage: React.FC = () => {
   const [activeTab, setActiveTab] = useState<string>('전체');
@@ -30,10 +25,12 @@ const HomePage: React.FC = () => {
     data: houseworks,
     error,
     isLoading,
+    refetch,
   } = useQuery({
     queryKey: ['houseworks', channelId, activeDate],
     queryFn: async () => await fetchHouseworks(activeDate),
   });
+  const { toast } = useToast();
 
   useEffect(() => {
     const fetchMyGroups = async () => {
@@ -79,26 +76,19 @@ const HomePage: React.FC = () => {
   };
 
   const handleAction = (id: number) => {
-    /**
-     * todo
-     * 해당 id에 해당하는 집안일 완료 처리
-     */
+    // 해당 id에 해당하는 집안일 완료 처리
   };
+
   const handleEdit = () => {
-    /**
-     * todo
-     * 해당 id에 해당하는 집안일을 집안일 추가페이지에 보내줌
-     * navigate로 라우팅하는데 파라미터를 집안일 id를 넘겨주면 됨
-     */
+    // 해당 id에 해당하는 집안일을 집안일 추가페이지에 보내줌
     console.log('edit');
   };
+
   const handleDelete = async (houseworkId: number) => {
-    /**
-     * todo
-     * 해당 id에 해당하는 집안일 삭제 처리
-     */
     const newChannelId = Number(channelId);
-    const deleteHouseworkResult = await deleteHousework({ channelId: newChannelId, houseworkId });
+    await deleteHousework({ channelId: newChannelId, houseworkId });
+    toast({ title: '집안일이 삭제되었습니다!' });
+    refetch();
   };
 
   return (

--- a/src/services/housework/deleteHouswork.ts
+++ b/src/services/housework/deleteHouswork.ts
@@ -1,0 +1,13 @@
+import { axiosInstance } from '@/services/axiosInstance';
+import { DeleteHouseworkReq, DeleteHouseworkRes } from '@/types/apis/houseworkApi';
+
+export const deleteHousework = async ({ channelId, houseworkId }: DeleteHouseworkReq) => {
+  try {
+    const response = await axiosInstance.delete<DeleteHouseworkRes>(
+      `/api/v1/channels/${channelId}/houseworks/${houseworkId}`
+    );
+    return response.data;
+  } catch (error) {
+    throw new Error('집안일 삭제 실패');
+  }
+};

--- a/src/store/useHomePageStore.ts
+++ b/src/store/useHomePageStore.ts
@@ -1,6 +1,5 @@
 import { create } from 'zustand';
 import { Group } from '@/types/apis/groupApi';
-import { Housework } from '@/types/apis/houseworkApi';
 import getFormattedDate from '@/utils/getFormattedDate';
 
 interface HomePageState {
@@ -15,9 +14,6 @@ interface HomePageState {
 
   weekText: string;
   setWeekText: (weekText: string) => void;
-
-  houseworks: Array<Housework>;
-  setHouseworks: (newHouseworks: Array<Housework>) => void;
 
   activeDate: string;
   setActiveDate: (newDate: string) => void;
@@ -38,9 +34,6 @@ const useHomePageStore = create<HomePageState>(set => ({
 
   weekText: '',
   setWeekText: weekText => set({ weekText: weekText }),
-
-  houseworks: [],
-  setHouseworks: newHouseworks => set({ houseworks: newHouseworks }),
 
   activeDate: getFormattedDate(new Date()),
   setActiveDate: newDate => set({ activeDate: newDate }),


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약

> 메인(홈) 페이지 - 집안일 삭제 기능 추가

## 📌 이슈 넘버

- #263 
- #376 

## 📝 작업 내용
- 집안일을 전역이 아닌 서버 상태 관리로 변경
- 집안일 삭제 함수 추가

## 📸 스크린샷(선택)
![image](https://github.com/user-attachments/assets/3ed2c78f-05d3-4af2-a5ea-098a1d01c509)


## 💬리뷰 요구사항(선택)

> 수정 할 사항 있으면 말씀해주세요!
