### PR TITLE
Feature/#375 add housework edit

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,10 +1,15 @@
 import { router } from '@/router';
 import { RouterProvider } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+const queryClient = new QueryClient();
 
 function App() {
   return (
     <>
-      <RouterProvider router={router} />
+      <QueryClientProvider client={queryClient}>
+        <RouterProvider router={router} />
+      </QueryClientProvider>
     </>
   );
 }

--- a/src/components/home/HouseworkList/HouseworkList.tsx
+++ b/src/components/home/HouseworkList/HouseworkList.tsx
@@ -4,9 +4,9 @@ import { Housework } from '@/types/apis/houseworkApi';
 
 export interface HouseworkListProps {
   items: Housework[];
-  handleAction: (id: number) => void;
-  handleEdit: () => void;
-  handleDelete: (id: number) => void;
+  handleAction: (houseworkId: number) => void;
+  handleEdit: (houseworkId: number) => void;
+  handleDelete: (houseworkId: number) => void;
 }
 
 const HouseworkList: React.FC<HouseworkListProps> = ({

--- a/src/components/home/HouseworkList/HouseworkListItem/HouseworkListItem.tsx
+++ b/src/components/home/HouseworkList/HouseworkListItem/HouseworkListItem.tsx
@@ -6,9 +6,9 @@ import { Housework } from '@/types/apis/houseworkApi';
 import { HOUSEWORK_STATUS } from '@/constants/homePage';
 
 export interface HouseworkListItemProps extends Housework {
-  handleAction: (id: number) => void;
-  handleEdit: () => void;
-  handleDelete: (id: number) => void;
+  handleAction: (houseworkId: number) => void;
+  handleEdit: (houseworkId: number) => void;
+  handleDelete: (houseworkId: number) => void;
 }
 
 const HouseworkListItem: React.FC<HouseworkListItemProps> = ({
@@ -45,7 +45,7 @@ const HouseworkListItem: React.FC<HouseworkListItemProps> = ({
         <div className='flex flex-col items-end justify-center gap-2'>
           <ControlDropdown
             id={houseworkId}
-            handleEdit={handleEdit}
+            handleEdit={() => handleEdit(houseworkId)}
             handleDelete={() => handleDelete(houseworkId)}
           />
           <div className='flex items-center gap-1'>

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -12,12 +12,7 @@ import { PAGE_SIZE } from '@/constants/common';
 import { getHouseworks } from '@/services/housework/getHouseworks';
 import { deleteHousework } from '@/services/housework/deleteHouswork';
 import { useQuery } from '@tanstack/react-query';
-
-/**
- * todo
- * 무한 스크롤 구현
- * housework는 전역 상태가 아니라 리액트 쿼리로 관리?
- */
+import { useToast } from '@/hooks/use-toast';
 
 const HomePage: React.FC = () => {
   const [activeTab, setActiveTab] = useState<string>('전체');
@@ -30,10 +25,12 @@ const HomePage: React.FC = () => {
     data: houseworks,
     error,
     isLoading,
+    refetch,
   } = useQuery({
     queryKey: ['houseworks', channelId, activeDate],
     queryFn: async () => await fetchHouseworks(activeDate),
   });
+  const { toast } = useToast();
 
   useEffect(() => {
     const fetchMyGroups = async () => {
@@ -79,26 +76,19 @@ const HomePage: React.FC = () => {
   };
 
   const handleAction = (id: number) => {
-    /**
-     * todo
-     * 해당 id에 해당하는 집안일 완료 처리
-     */
+    // 해당 id에 해당하는 집안일 완료 처리
   };
+
   const handleEdit = () => {
-    /**
-     * todo
-     * 해당 id에 해당하는 집안일을 집안일 추가페이지에 보내줌
-     * navigate로 라우팅하는데 파라미터를 집안일 id를 넘겨주면 됨
-     */
+    // 해당 id에 해당하는 집안일을 집안일 추가페이지에 보내줌
     console.log('edit');
   };
+
   const handleDelete = async (houseworkId: number) => {
-    /**
-     * todo
-     * 해당 id에 해당하는 집안일 삭제 처리
-     */
     const newChannelId = Number(channelId);
-    const deleteHouseworkResult = await deleteHousework({ channelId: newChannelId, houseworkId });
+    await deleteHousework({ channelId: newChannelId, houseworkId });
+    toast({ title: '집안일이 삭제되었습니다!' });
+    refetch();
   };
 
   return (

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -13,24 +13,20 @@ import { getHouseworks } from '@/services/housework/getHouseworks';
 import { deleteHousework } from '@/services/housework/deleteHouswork';
 import { useQuery } from '@tanstack/react-query';
 import { useToast } from '@/hooks/use-toast';
+import { useNavigate } from 'react-router-dom';
 
 const HomePage: React.FC = () => {
   const [activeTab, setActiveTab] = useState<string>('전체');
-
   const { setWeekText, setCurrentGroup, setGroups, activeDate, homePageNumber } =
     useHomePageStore();
   const { channelId } = useParams();
   const [chargers, setChargers] = useState<{ name: string }[]>([{ name: '전체' }]);
-  const {
-    data: houseworks,
-    error,
-    isLoading,
-    refetch,
-  } = useQuery({
+  const { data: houseworks, refetch } = useQuery({
     queryKey: ['houseworks', channelId, activeDate],
     queryFn: async () => await fetchHouseworks(activeDate),
   });
   const { toast } = useToast();
+  const navigate = useNavigate();
 
   useEffect(() => {
     const fetchMyGroups = async () => {
@@ -75,13 +71,13 @@ const HomePage: React.FC = () => {
     return getHouseworksResult.result.responses;
   };
 
-  const handleAction = (id: number) => {
+  const handleAction = (houseworkId: number) => {
     // 해당 id에 해당하는 집안일 완료 처리
+    console.log(houseworkId);
   };
 
-  const handleEdit = () => {
-    // 해당 id에 해당하는 집안일을 집안일 추가페이지에 보내줌
-    console.log('edit');
+  const handleEdit = (houseworkId: number) => {
+    navigate(`/add-housework/edit/${channelId}/${houseworkId}/step1`);
   };
 
   const handleDelete = async (houseworkId: number) => {

--- a/src/pages/HouseWorkStepOnePage.tsx
+++ b/src/pages/HouseWorkStepOnePage.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import Button from '@/components/common/button/Button/Button';
 import OpenSheetBtn from '@/components/common/button/OpenSheetBtn/OpenSheetBtn';
@@ -9,6 +9,7 @@ import DueDateSheet from '@/components/housework/DueDateSheet/DueDateSheet';
 import TimeControl from '@/components/housework/TimeControl/TimeControl';
 import useAddHouseWorkStore from '@/store/useAddHouseWorkStore';
 import useHomePageStore from '@/store/useHomePageStore';
+import { useParams } from 'react-router-dom';
 
 export interface SelectedTime {
   hour: string;
@@ -23,8 +24,14 @@ const HouseWorkStepOnePage = () => {
   const [isHouseWorkSheetOpen, setHouseWorkSheetOpen] = useState(false);
   const [isDueDateSheetOpen, setDueDateSheetOpen] = useState(false);
   const [time, setTime] = useState<SelectedTime | null>(startTime);
+  const { channelId, houseworkId } = useParams();
 
-  console.log('전역:', task, category, startDate, startTime);
+  useEffect(() => {
+    if (channelId && houseworkId) {
+      // todo
+      // task, category, startDate, startTime을 미리 채워넣으면 됨
+    }
+  }, []);
 
   const handleBackClick = () => {
     navigate(`/main/${currentGroup.channelId}`);

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -141,6 +141,10 @@ export const router = createBrowserRouter([
         element: <HouseWorkStepOnePage />,
       },
       {
+        path: '/add-housework/edit/:channelId/:houseworkId/step1/',
+        element: <HouseWorkStepOnePage />,
+      },
+      {
         path: '/add-housework/step2',
         element: <HouseWorkStepTwoPage />,
       },

--- a/src/services/housework/deleteHouswork.ts
+++ b/src/services/housework/deleteHouswork.ts
@@ -1,0 +1,13 @@
+import { axiosInstance } from '@/services/axiosInstance';
+import { DeleteHouseworkReq, DeleteHouseworkRes } from '@/types/apis/houseworkApi';
+
+export const deleteHousework = async ({ channelId, houseworkId }: DeleteHouseworkReq) => {
+  try {
+    const response = await axiosInstance.delete<DeleteHouseworkRes>(
+      `/api/v1/channels/${channelId}/houseworks/${houseworkId}`
+    );
+    return response.data;
+  } catch (error) {
+    throw new Error('집안일 삭제 실패');
+  }
+};

--- a/src/services/housework/putHousework.ts
+++ b/src/services/housework/putHousework.ts
@@ -1,0 +1,22 @@
+import { axiosInstance } from '@/services/axiosInstance';
+import { PutHouseworkReq, PutHouseworkRes } from '@/types/apis/houseworkApi';
+
+export const putHousework = async ({
+  channelId,
+  houseworkId,
+  category,
+  task,
+  startDate,
+  startTime,
+  userId,
+}: PutHouseworkReq) => {
+  try {
+    const response = await axiosInstance.put<PutHouseworkRes>(
+      `api/v1/channels/${channelId}/houseworks/${houseworkId}`,
+      { category, task, startDate, startTime, userId }
+    );
+    return response.data;
+  } catch (error) {
+    throw new Error('집안일 수정 실패');
+  }
+};

--- a/src/store/useHomePageStore.ts
+++ b/src/store/useHomePageStore.ts
@@ -1,6 +1,5 @@
 import { create } from 'zustand';
 import { Group } from '@/types/apis/groupApi';
-import { Housework } from '@/types/apis/houseworkApi';
 import getFormattedDate from '@/utils/getFormattedDate';
 
 interface HomePageState {
@@ -15,9 +14,6 @@ interface HomePageState {
 
   weekText: string;
   setWeekText: (weekText: string) => void;
-
-  houseworks: Array<Housework>;
-  setHouseworks: (newHouseworks: Array<Housework>) => void;
 
   activeDate: string;
   setActiveDate: (newDate: string) => void;
@@ -38,9 +34,6 @@ const useHomePageStore = create<HomePageState>(set => ({
 
   weekText: '',
   setWeekText: weekText => set({ weekText: weekText }),
-
-  houseworks: [],
-  setHouseworks: newHouseworks => set({ houseworks: newHouseworks }),
 
   activeDate: getFormattedDate(new Date()),
   setActiveDate: newDate => set({ activeDate: newDate }),

--- a/src/types/apis/houseworkApi.ts
+++ b/src/types/apis/houseworkApi.ts
@@ -36,9 +36,9 @@ export interface AddHouseworkRes extends BaseRes {
 }
 
 // 집안일 수정
-export interface EditHouseworkReq extends HouseworkCommonReq, Pick<Housework, 'houseworkId'> {}
+export interface PutHouseworkReq extends HouseworkCommonReq, Pick<Housework, 'houseworkId'> {}
 
-export interface EditHouseworkRes extends BaseRes {
+export interface PutHouseworkRes extends BaseRes {
   result: {};
 }
 


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약

> 메인(홈) 페이지 - 집안일 수정 클릭시 라우팅

## 📌 이슈 넘버
- #263 
- #375 

## 📝 작업 내용
- 집안일 수정 함수 추가
- 메인에서 집안일 추가페이지로 라우팅 (파라미터로 그룹ID, 집안일ID 전달)

## 📸 스크린샷(선택)
![image](https://github.com/user-attachments/assets/bb1f8e2b-ec38-42ef-adb1-28b3098a9be0)


## 💬리뷰 요구사항(선택)

> 수정 할 사항 있으면 말씀해주세요