### PR TITLE
Feature/#384-전역에서 받아오던 channelId를 params로 받아오게 수정

### DIFF
--- a/src/hooks/usePresetSetting.ts
+++ b/src/hooks/usePresetSetting.ts
@@ -6,16 +6,15 @@ import {
   getAllCategoryList,
 } from '@/services/preset';
 import usePresetSettingStore from '@/store/usePresetSettingStore';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 import { PresetDefault, PresetTabName } from '@/constants';
-import useHomePageStore from '@/store/useHomePageStore';
 
 const usePresetSetting = () => {
   const navigate = useNavigate();
   const { setCategoryList, setDeleteButtonStates, activeTab, setPresetData } =
     usePresetSettingStore();
-  const { currentGroup } = useHomePageStore();
-  const channelId = currentGroup.channelId;
+  const { channelId: strChannelId } = useParams();
+  const channelId = Number(strChannelId);
 
   useEffect(() => {
     initCategoryList();


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약

- 프리셋설정페이지 > 전역에서 받아오던 channelId를 params로 받아오게 수정

## 📌 이슈 넘버

- #384 

## 📝 작업 내용
- 전역에서 받아오던 channelId를 params로 받아오게 수정

## 📸 스크린샷(선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
