### PR TITLE
Feature/#374-집안일 완료 기능 추가

### DIFF
--- a/src/components/home/HouseworkList/HouseworkListItem/HouseworkListItem.tsx
+++ b/src/components/home/HouseworkList/HouseworkListItem/HouseworkListItem.tsx
@@ -4,6 +4,7 @@ import HouseworkCategoryTag from '@/components/common/tag/HouseworkCatetoryTag/H
 import ControlDropdown from '@/components/home/ControlDropdown/ControlDropdown';
 import { Housework } from '@/types/apis/houseworkApi';
 import { HOUSEWORK_STATUS } from '@/constants/homePage';
+import convertTimeTo12HourFormat from '@/utils/convertTime';
 
 export interface HouseworkListItemProps extends Housework {
   handleAction: (houseworkId: number) => void;
@@ -16,6 +17,7 @@ const HouseworkListItem: React.FC<HouseworkListItemProps> = ({
   category,
   task,
   startTime,
+  isAllDay,
   assignee,
   status,
   handleAction,
@@ -50,7 +52,9 @@ const HouseworkListItem: React.FC<HouseworkListItemProps> = ({
           />
           <div className='flex items-center gap-1'>
             <div className='h-5 w-5 border border-solid'></div>
-            <p className='text-12'>{startTime}</p>
+            <p className='text-12'>
+              {isAllDay ? '하루 종일' : convertTimeTo12HourFormat(startTime!)}
+            </p>
           </div>
         </div>
       </div>

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -14,6 +14,7 @@ import { deleteHousework } from '@/services/housework/deleteHouswork';
 import { useQuery } from '@tanstack/react-query';
 import { useToast } from '@/hooks/use-toast';
 import { useNavigate } from 'react-router-dom';
+import { changeHouseworkStatus } from '@/services/housework/changeHouseworkStatus';
 
 const HomePage: React.FC = () => {
   const [activeTab, setActiveTab] = useState<string>('전체');
@@ -71,9 +72,15 @@ const HomePage: React.FC = () => {
     return getHouseworksResult.result.responses;
   };
 
-  const handleAction = (houseworkId: number) => {
+  const handleAction = async (houseworkId: number) => {
     // 해당 id에 해당하는 집안일 완료 처리
     console.log(houseworkId);
+    const newChannelId = Number(channelId);
+    const houseworkStatusChangeResult = await changeHouseworkStatus({
+      channelId: newChannelId,
+      houseworkId,
+    });
+    console.log(houseworkStatusChangeResult);
   };
 
   const handleEdit = (houseworkId: number) => {

--- a/src/services/housework/changeHouseworkStatus.ts
+++ b/src/services/housework/changeHouseworkStatus.ts
@@ -1,0 +1,16 @@
+import { axiosInstance } from '@/services/axiosInstance';
+import { ChangeHouseworkStatusReq, ChangeHouseworkStatusRes } from '@/types/apis/houseworkApi';
+
+export const changeHouseworkStatus = async ({
+  channelId,
+  houseworkId,
+}: ChangeHouseworkStatusReq) => {
+  try {
+    const response = await axiosInstance.put<ChangeHouseworkStatusRes>(
+      `/api/v1/channels/${channelId}/houseworks/${houseworkId}/changeStatus`
+    );
+    return response.data;
+  } catch (error) {
+    throw new Error('집안일 상태 변경 실패');
+  }
+};

--- a/src/types/apis/houseworkApi.ts
+++ b/src/types/apis/houseworkApi.ts
@@ -51,6 +51,15 @@ export interface DeleteHouseworkRes extends BaseRes {
   result: {};
 }
 
+// 집안일 상태 변경
+export interface ChangeHouseworkStatusReq
+  extends Pick<Common, 'channelId'>,
+    Pick<Housework, 'houseworkId'> {}
+
+export interface ChangeHouseworkStatusRes extends BaseRes {
+  result: {};
+}
+
 // 집안일 목록 조회
 export interface GetHouseworkReq extends Pick<Common, 'channelId'> {
   targetDate: string;

--- a/src/utils/convertTime.ts
+++ b/src/utils/convertTime.ts
@@ -1,0 +1,7 @@
+export default function convertTimeTo12HourFormat(time: string): string {
+  const [hours, minutes] = time.split(':').map(Number);
+  const period = hours >= 12 ? '오후' : '오전';
+  const adjustedHours = hours % 12 === 0 ? 12 : hours % 12;
+
+  return `${period} ${adjustedHours}:${minutes.toString().padStart(2, '0')}`;
+}


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약

> 메인(홈) 페이지 - 집안일 완료 기능 추가

## 📌 이슈 넘버

- #263 
- #374 

## 📝 작업 내용
- 집안일 완료 버튼 클릭시 완료 체크
- 이미 완료가 되어있다면 미완료로 변경
- 하루종일 여부 판단후 하루종일이라면 하루종일이라고 표시
- 23:00 형태의 시간을 오후 11:00의 형태로 변경

## 📸 스크린샷(선택)
![image](https://github.com/user-attachments/assets/d5cded97-0c43-4c0c-b49b-c46ffad6a8d9)


## 💬리뷰 요구사항(선택)

> 수정 할 사항 있으면 말씀해주세요!
