### PR TITLE
Feature/#407-집안일 id별 상세 정보 조회 로직 구현

### DIFF
--- a/src/pages/HouseWorkStepOnePage.tsx
+++ b/src/pages/HouseWorkStepOnePage.tsx
@@ -9,6 +9,7 @@ import DueDateSheet from '@/components/housework/DueDateSheet/DueDateSheet';
 import TimeControl from '@/components/housework/TimeControl/TimeControl';
 import useAddHouseWorkStore from '@/store/useAddHouseWorkStore';
 import { useParams } from 'react-router-dom';
+import { getHouseworkById } from '@/services/housework/getHouseworkById';
 
 export interface SelectedTime {
   hour: string;
@@ -18,21 +19,35 @@ export interface SelectedTime {
 
 const HouseWorkStepOnePage = () => {
   const navigate = useNavigate();
-  const { task, category, startDate, startTime, setStartTime } = useAddHouseWorkStore();
+  const { task, startDate, startTime, setStartTime, reset } = useAddHouseWorkStore();
   const [isHouseWorkSheetOpen, setHouseWorkSheetOpen] = useState(false);
   const [isDueDateSheetOpen, setDueDateSheetOpen] = useState(false);
   const [time, setTime] = useState<SelectedTime | null>(startTime);
-  const { channelId, houseworkId } = useParams();
+  const { channelId: strChannelId, houseworkId: strHouseworkId } = useParams();
+
+  const channelId = Number(strChannelId);
+  const houseworkId = Number(strHouseworkId);
 
   useEffect(() => {
     if (channelId && houseworkId) {
       // todo
       // task, category, startDate, startTime을 미리 채워넣으면 됨
+      const fetchHouseworkById = async () => {
+        try {
+          const response = await getHouseworkById({ channelId, houseworkId });
+          console.log(response);
+        } catch (error) {
+          console.error('집안일 상세 정보 조회 실패:', error);
+        }
+      };
+
+      fetchHouseworkById();
     }
   }, []);
 
   const handleBackClick = () => {
     navigate(`/main/${channelId}`);
+    reset();
   };
   const handleHouseWorkClick = () => {
     setHouseWorkSheetOpen(true);
@@ -44,7 +59,7 @@ const HouseWorkStepOnePage = () => {
   const handleNextClick = () => {
     setStartTime(time);
 
-    if (houseworkId) navigate(`/add-housework/${channelId}/${houseworkId}/step2`);
+    if (houseworkId) navigate(`/add-housework/edit/${channelId}/${houseworkId}/step2`);
     else navigate(`/add-housework/${channelId}/step2`);
   };
 

--- a/src/pages/HouseWorkStepTwoPage.tsx
+++ b/src/pages/HouseWorkStepTwoPage.tsx
@@ -40,7 +40,7 @@ const HouseWorkStepTwoPage = () => {
   console.log('전역:', task, category, startDate, startTime, userId);
 
   const handleBackClick = () => {
-    if (houseworkId) navigate(`/add-housework/${channelId}/${houseworkId}/step1`);
+    if (houseworkId) navigate(`/add-housework/edit/${channelId}/${houseworkId}/step1`);
     else navigate(`/add-housework/${channelId}/step1`);
   };
 

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -150,7 +150,7 @@ export const router = createBrowserRouter([
       },
       {
         path: '/add-housework/edit/:channelId/:houseworkId/step2/',
-        element: <HouseWorkStepOnePage />,
+        element: <HouseWorkStepTwoPage />,
       },
     ],
   },

--- a/src/services/housework/getHouseworkById.ts
+++ b/src/services/housework/getHouseworkById.ts
@@ -1,0 +1,13 @@
+import { axiosInstance } from '@/services/axiosInstance';
+import { GetHouseworkByIdReq, GetHouseworkByIdRes } from '@/types/apis/houseworkApi';
+
+export const getHouseworkById = async ({ channelId, houseworkId }: GetHouseworkByIdReq) => {
+  try {
+    const response = await axiosInstance.get<GetHouseworkByIdRes>(
+      `/api/v1/channels/${channelId}/houseworks/${houseworkId}`
+    );
+    return response.data;
+  } catch (error) {
+    throw new Error('집안일 id별 상세 정보 조회 실패');
+  }
+};

--- a/src/types/apis/houseworkApi.ts
+++ b/src/types/apis/houseworkApi.ts
@@ -35,6 +35,15 @@ export interface AddHouseworkRes extends BaseRes {
   result: {};
 }
 
+//집안일 id별 상세 정보 조회
+export interface GetHouseworkByIdReq
+  extends Pick<Common, 'channelId'>,
+    Pick<Housework, 'houseworkId'> {}
+
+export interface GetHouseworkByIdRes extends BaseRes {
+  result: Housework;
+}
+
 // 집안일 수정
 export interface PutHouseworkReq extends HouseworkCommonReq, Pick<Housework, 'houseworkId'> {}
 


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약

> ex) 메인페이지 - 라우트 연결

아직 api가 안되서 로직만 짰습니다.
그리고 navigate 오류나는거 수정했습니다.

## 📌 이슈 넘버

> ex) #이슈번호, #이슈번호

- [x] #410 

## 📝 작업 내용

## 📸 스크린샷(선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
