### PR TITLE
Feature/#414-통계 주간월간 API 타입정의, 호출부 추가

### DIFF
--- a/src/services/statistics/GetMonthlyMVP.ts
+++ b/src/services/statistics/GetMonthlyMVP.ts
@@ -1,0 +1,14 @@
+import { axiosInstance } from '@/services/axiosInstance';
+import { GetMonthlyMVPReq, GetMonthlyMVPRes } from '@/types/apis/statisticsApi';
+
+export const getMonthlyMVP = async (data: GetMonthlyMVPReq) => {
+  try {
+    const response = await axiosInstance.get<GetMonthlyMVPRes>(
+      `/api/v1/channels/${data.channelId}/statistics/monthly/${data.targetMonth}/mvp`
+    );
+    return response.data;
+  } catch (error) {
+    console.error('월간 통계 MVP 조회 실패:', error);
+    throw error;
+  }
+};

--- a/src/services/statistics/GetMonthlyScore.ts
+++ b/src/services/statistics/GetMonthlyScore.ts
@@ -1,0 +1,14 @@
+import { axiosInstance } from '@/services/axiosInstance';
+import { GetMonthlyScoreReq, GetMonthlyScoreRes } from '@/types/apis/statisticsApi';
+
+export const getMonthlyScore = async (data: GetMonthlyScoreReq) => {
+  try {
+    const response = await axiosInstance.get<GetMonthlyScoreRes>(
+      `/api/v1/channels/${data.channelId}/statistics/monthly/${data.targetMonth}/score`
+    );
+    return response.data;
+  } catch (error) {
+    console.error('월간 통계 캘린더 조회 실패:', error);
+    throw error;
+  }
+};

--- a/src/services/statistics/GetWeeklyScore.ts
+++ b/src/services/statistics/GetWeeklyScore.ts
@@ -1,0 +1,14 @@
+import { axiosInstance } from '@/services/axiosInstance';
+import { GetWeeklyScoreReq, GetWeeklyScoreRes } from '@/types/apis/statisticsApi';
+
+export const getWeeklyScore = async (data: GetWeeklyScoreReq) => {
+  try {
+    const response = await axiosInstance.get<GetWeeklyScoreRes>(
+      `/api/v1/channels/${data.channelId}/statistics/weekly/${data.targetDate}/score`
+    );
+    return response.data;
+  } catch (error) {
+    console.error('주간 통계 랭킹 조회 실패:', error);
+    throw error;
+  }
+};

--- a/src/services/statistics/GetWeeklyTotalCount.ts
+++ b/src/services/statistics/GetWeeklyTotalCount.ts
@@ -1,0 +1,14 @@
+import { axiosInstance } from '@/services/axiosInstance';
+import { GetWeeklyTotalCountReq, GetWeeklyTotalCountRes } from '@/types/apis/statisticsApi';
+
+export const getWeeklyTotalCount = async (data: GetWeeklyTotalCountReq) => {
+  try {
+    const response = await axiosInstance.get<GetWeeklyTotalCountRes>(
+      `/api/v1/channels/${data.channelId}/statistics/weekly/${data.targetDate}/totalCount`
+    );
+    return response.data;
+  } catch (error) {
+    console.error('주간 통계 개수 조회 실패:', error);
+    throw error;
+  }
+};

--- a/src/types/apis/statisticsApi.ts
+++ b/src/types/apis/statisticsApi.ts
@@ -1,0 +1,69 @@
+import { BaseRes } from '@/types/apis/baseResponse';
+import { Common } from '@/types/apis/commonApi';
+
+export interface WeeklyMemberScore {
+  /** 닉네임 */
+  nickname: string;
+  /** 완료 개수 */
+  completeCount: number;
+}
+export interface GetWeeklyScoreReq extends Pick<Common, 'channelId'> {
+  /** 선택 날짜 (YYYY-MM-DD) */
+  targetDate: string;
+}
+export interface GetWeeklyScoreRes extends BaseRes {
+  result: {
+    completeScoreSortedResponse: Array<WeeklyMemberScore>;
+  };
+}
+
+export interface GetWeeklyTotalCountReq extends Pick<Common, 'channelId'> {
+  /** 선택 날짜 (YYYY-MM-DD) */
+  targetDate: string;
+}
+export interface GetWeeklyTotalCountRes extends BaseRes {
+  result: {
+    /** 완료 개수 */
+    completeCount: number;
+    /** 미완료 개수 */
+    notCompleteCount: number;
+    /** 칭찬 개수 */
+    complimentCount: number;
+    /** 찌르기 개수 */
+    pokeCount: number;
+  };
+}
+
+export interface MonthlyDateScore {
+  /** 날짜 (YYYY-MM-DD) */
+  date: string;
+  /** 전체 할 일 개수 */
+  totalTasks: number;
+  /** 완료한 일의 개수 */
+  completedTasks: number;
+  /** 상태 */
+  status: string;
+}
+
+export interface GetMonthlyScoreReq extends Pick<Common, 'channelId'> {
+  /** 선택 월 (YYYY-MM) */
+  targetMonth: string;
+}
+export interface GetMonthlyScoreRes extends BaseRes {
+  result: {
+    monthlyStatistics: Array<MonthlyDateScore>;
+  };
+}
+
+export interface GetMonthlyMVPReq extends Pick<Common, 'channelId'> {
+  /** 선택 월 (YYYY-MM) */
+  targetMonth: string;
+}
+export interface GetMonthlyMVPRes extends BaseRes {
+  result: {
+    /** 칭찬 MVP */
+    complimentMVPNickName: string;
+    /** 찌르기 MVP */
+    pokeMVPNickName: string;
+  };
+}


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약

- 통계 > 주간월간 API 타입정의, 호출부 추가

## 📌 이슈 넘버

- #414 

## 📝 작업 내용
- Swagger 로 제공된 req, res 에 맞게 타입 정의
- API 호출부 추가

## 📸 스크린샷(선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
