### PR TITLE
Feature/#429 - 통계 잔디, 완료 컴포넌트 디자인 적용 완료

### DIFF
--- a/src/components/common/icon/ArrowLeftIcon.tsx
+++ b/src/components/common/icon/ArrowLeftIcon.tsx
@@ -1,6 +1,17 @@
-const ArrowLeftIcon = () => {
+interface ArrowLeftIconProps {
+  className?: string;
+}
+
+const ArrowLeftIcon: React.FC<ArrowLeftIconProps> = ({ className }) => {
   return (
-    <svg width='24' height='24' viewBox='0 0 24 24' fill='none' xmlns='http://www.w3.org/2000/svg'>
+    <svg
+      width='24'
+      height='24'
+      viewBox='0 0 24 24'
+      fill='none'
+      xmlns='http://www.w3.org/2000/svg'
+      className={className}
+    >
       <g clip-path='url(#clip0_2309_15909)'>
         <path
           fill-rule='evenodd'

--- a/src/components/common/icon/ArrowRightIcon.tsx
+++ b/src/components/common/icon/ArrowRightIcon.tsx
@@ -1,6 +1,17 @@
-const ArrowRightIcon = () => {
+interface ArrowRightIconProps {
+  className?: string;
+}
+
+const ArrowRightIcon: React.FC<ArrowRightIconProps> = ({ className }) => {
   return (
-    <svg width='24' height='24' viewBox='0 0 24 24' fill='none' xmlns='http://www.w3.org/2000/svg'>
+    <svg
+      width='24'
+      height='24'
+      viewBox='0 0 24 24'
+      fill='none'
+      xmlns='http://www.w3.org/2000/svg'
+      className={className}
+    >
       <path
         fill-rule='evenodd'
         clip-rule='evenodd'

--- a/src/components/statistics/monthly/Completion/Completion.tsx
+++ b/src/components/statistics/monthly/Completion/Completion.tsx
@@ -1,15 +1,15 @@
-interface CompletionDateProps {
+interface CompletionProps {
   count: number;
-  color?: string;
+  icon: React.ReactNode;
 }
 
-const CompletionDate: React.FC<CompletionDateProps> = ({ count, color = 'text-[#989393]' }) => {
+const Completion: React.FC<CompletionProps> = ({ count, icon }) => {
   return (
-    <div className={`font-label flex items-center gap-2 ${color}`}>
-      <i className='h-4 w-4 border border-solid border-black02'></i>
+    <div className={`flex items-center gap-1 font-label`}>
+      {icon}
       <p>{count}</p>
     </div>
   );
 };
 
-export default CompletionDate;
+export default Completion;

--- a/src/components/statistics/monthly/MonthlyGrass/MonthlyGrass.tsx
+++ b/src/components/statistics/monthly/MonthlyGrass/MonthlyGrass.tsx
@@ -1,4 +1,6 @@
 import Calendar from 'react-calendar';
+import { ArrowLeftIcon, ArrowRightIcon } from '@/components/common/icon';
+import { useState } from 'react';
 
 enum CompletionStatus {
   ALL_DONE = 'ALL_DONE',
@@ -22,6 +24,9 @@ const MonthlyGrass: React.FC<MonthlyGrassProps> = ({ completionData, onMonthChan
   const today = new Date();
   const firstDayCurrentMonth = new Date(today.getFullYear(), today.getMonth(), 1);
   const lastDayPreviousMonth = new Date(firstDayCurrentMonth.getTime() - 1);
+
+  const [currentDate, setCurrentDate] = useState(lastDayPreviousMonth);
+  const maxDate = lastDayPreviousMonth;
 
   const getStatus = (date: Date): CompletionStatus => {
     const dateString = date.toLocaleDateString('en-CA');
@@ -60,9 +65,25 @@ const MonthlyGrass: React.FC<MonthlyGrassProps> = ({ completionData, onMonthChan
       locale='ko'
       minDetail='month'
       maxDetail='month'
-      onActiveStartDateChange={handleMonthChange}
+      onActiveStartDateChange={props => {
+        if (props.activeStartDate) {
+          setCurrentDate(props.activeStartDate);
+          handleMonthChange(props);
+        }
+      }}
       navigationLabel={({ date }) => `${date.getFullYear()}년 ${date.getMonth() + 1}월`}
       formatDay={(_locale, date) => date.getDate().toString()}
+      prevLabel={<ArrowLeftIcon />}
+      nextLabel={
+        <ArrowRightIcon
+          className={`text-main transition-colors ${
+            currentDate.getFullYear() === maxDate.getFullYear() &&
+            currentDate.getMonth() >= maxDate.getMonth()
+              ? 'opacity-30'
+              : ''
+          }`}
+        />
+      }
     />
   );
 };

--- a/src/index.css
+++ b/src/index.css
@@ -106,14 +106,14 @@ body:has(.react-modal-sheet-container) {
   @apply w-full;
 }
 .react-calendar__navigation {
-  @apply text-main font-subhead mb-4 flex items-center justify-center gap-4 text-center;
+  @apply mb-4 flex items-center justify-center gap-8 text-center text-main font-subhead;
 }
 .react-calendar__navigation__label {
   @apply grow-0 !important;
 }
 .react-calendar__navigation__next-button,
 .react-calendar__navigation__prev-button {
-  @apply text-sub flex items-center justify-center text-20 font-bold;
+  @apply flex items-center justify-center text-20 font-bold text-sub;
 }
 .react-calendar__navigation__next2-button,
 .react-calendar__navigation__prev2-button,
@@ -127,7 +127,7 @@ body:has(.react-modal-sheet-container) {
   @apply w-full;
 }
 .react-calendar__month-view__days {
-  @apply font-body !grid w-full !grid-cols-7 justify-items-center gap-1;
+  @apply !grid w-full !grid-cols-7 justify-items-center gap-1 font-body;
 }
 .react-calendar__month-view__days__day {
   @apply flex aspect-square w-10 items-center justify-center;

--- a/src/pages/MonthlyStatisticsPage.tsx
+++ b/src/pages/MonthlyStatisticsPage.tsx
@@ -1,4 +1,5 @@
-import CompletionDate from '@/components/statistics/monthly/Completion/Completion';
+import { ChartIcon, CheckFillIcon } from '@/components/common/icon';
+import Completion from '@/components/statistics/monthly/Completion/Completion';
 import MonthlyGoodBad from '@/components/statistics/monthly/MonthlyGoodBad/MonthlyGoodBad';
 import MonthlyGrass from '@/components/statistics/monthly/MonthlyGrass/MonthlyGrass';
 import { monthlyGoodBad } from '@/mock/monthlyGoodBad';
@@ -28,14 +29,14 @@ const MonthlyStatisticsPage = () => {
   return (
     <div className='flex flex-col gap-4'>
       <MonthlyGrass completionData={monthlyGrassData.dates} onMonthChange={handleMonthChange} />
-      <p className='text-gray1 font-label flex items-center gap-3'>
+      <p className='flex items-center gap-3 text-gray1 font-label'>
         이번달에는
         <p className='flex items-center gap-3'>
-          <span className='text-main flex items-center'>
-            <CompletionDate count={currentMonthStats.completionRate} color='text-main' />%
+          <span className='flex items-center text-main'>
+            <Completion count={currentMonthStats.completionRate} icon={<ChartIcon />} />%
           </span>
-          <span className='text-main flex items-center'>
-            <CompletionDate count={currentMonthStats.completedDays} color='text-main' />
+          <span className='flex items-center text-main'>
+            <Completion count={currentMonthStats.completedDays} icon={<CheckFillIcon />} />
             개의
           </span>
         </p>


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약

> 통계 페이지 - 잔디, 완료

## 📌 이슈 넘버

> #429

## 📝 작업 내용
- 잔디 이전, 다음 버튼 아이콘으로 갈아끼우기
- 다음 달로 갈 수 없을때 투명도 30적용
- 완료일, 완료율 컴포넌트에 아이콘 넘기기
- arrow 아이콘  props로 스타일 받을 수 있도록 수정

## 📸 스크린샷(선택)
![image](https://github.com/user-attachments/assets/ea9f9a2a-ff27-4e65-b1b2-d1533c9f2d6b)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
