### PR TITLE
Feature/#466 - 아이템 비었을 때 처리

### DIFF
--- a/src/pages/GroupSelectPage.tsx
+++ b/src/pages/GroupSelectPage.tsx
@@ -6,6 +6,7 @@ import { useNavigate } from 'react-router-dom';
 import useHomePageStore from '@/store/useHomePageStore';
 import { getMyGroup } from '@/services/group/getMyGroup';
 import { Group } from '@/types/apis/groupApi';
+import { NoGroupIcon } from '@/components/common/icon';
 
 const GroupSelectPage = () => {
   const navigate = useNavigate();
@@ -45,8 +46,9 @@ const GroupSelectPage = () => {
             />
           ))
         ) : (
-          <div className='font-label flex flex-1 items-center justify-center whitespace-pre-line text-center text-gray03'>
-            {'현재 방이 없어요\n새로운 방을 만들어보세요'}
+          <div className='flex flex-1 flex-col items-center justify-center gap-4 whitespace-pre-line text-center text-gray2'>
+            <NoGroupIcon />
+            <p className='font-subhead'>{'현재 방이 없어요\n새로운 방을 만들어보세요'}</p>
           </div>
         )}
       </div>

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -15,6 +15,7 @@ import { useQuery } from '@tanstack/react-query';
 import { useToast } from '@/hooks/use-toast';
 import { useNavigate } from 'react-router-dom';
 import { changeHouseworkStatus } from '@/services/housework/changeHouseworkStatus';
+import { NoHouseWorkIcon } from '@/components/common/icon';
 
 const HomePage: React.FC = () => {
   const [activeTab, setActiveTab] = useState<string>('전체');
@@ -102,7 +103,16 @@ const HomePage: React.FC = () => {
         handleSetActiveTab={setActiveTab}
         chargers={chargers}
       />
-      {houseworks && (
+      {!houseworks ||
+      houseworks.filter(item => item.assignee === activeTab || activeTab === '전체').length ===
+        0 ? (
+        <div className='flex h-[calc(100vh-280px)] flex-1 flex-col items-center justify-center gap-4 whitespace-pre-line text-center text-gray2'>
+          <NoHouseWorkIcon />
+          <p className='text-gray2 font-subhead'>
+            {'현재 집안일 목록이 없어요\n새로운 목록을 만들어보세요'}
+          </p>
+        </div>
+      ) : (
         <HouseworkList
           items={houseworks.filter(item => item.assignee === activeTab || activeTab === '전체')}
           handleAction={handleAction}
@@ -110,7 +120,6 @@ const HomePage: React.FC = () => {
           handleDelete={handleDelete}
         />
       )}
-
       <GroupSelectSheet />
     </div>
   );


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약

> 그룹 선택, 집안일 추가 - 비었을 때

## 📌 이슈 넘버

> #466

## 📝 작업 내용
- 그룹 선택에서 그룹이 없는 경우
- 집안일 페이지에서 집안일이 없는 경우

## 📸 스크린샷(선택)
![image](https://github.com/user-attachments/assets/9febbe51-2d8d-4407-8738-231d7b471dde)
![image](https://github.com/user-attachments/assets/b8584aa0-c9b5-4e6f-8ed6-c521e62012d8)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
