### PR TITLE
Feature/#470-아이콘태그 스타일링 추가

### DIFF
--- a/src/components/common/icon/IconView.tsx
+++ b/src/components/common/icon/IconView.tsx
@@ -14,7 +14,7 @@ import {
   BathRoomIcon,
   BedRoomIcon,
   EtcIcon,
-  LivingRoom,
+  LivingRoomIcon,
   KitchenIcon,
   OutIcon,
   MetalIcon,
@@ -97,8 +97,8 @@ const IconView = () => {
         <EtcIcon />
       </div>
       <div className='flex flex-col items-center gap-2'>
-        <p className='text-sm text-gray-600'>LivingRoom</p>
-        <LivingRoom />
+        <p className='text-sm text-gray-600'>LivingRoomIcon</p>
+        <LivingRoomIcon />
       </div>
       <div className='flex flex-col items-center gap-2'>
         <p className='text-sm text-gray-600'>KitchenIcon</p>

--- a/src/components/common/icon/LivingRoomIcon.tsx
+++ b/src/components/common/icon/LivingRoomIcon.tsx
@@ -1,4 +1,4 @@
-const LivingRoom = () => {
+const LivingRoomIcon = () => {
   return (
     <svg width='24' height='24' viewBox='0 0 24 24' fill='none' xmlns='http://www.w3.org/2000/svg'>
       <path
@@ -26,4 +26,4 @@ const LivingRoom = () => {
   );
 };
 
-export default LivingRoom;
+export default LivingRoomIcon;

--- a/src/components/common/icon/index.ts
+++ b/src/components/common/icon/index.ts
@@ -13,7 +13,7 @@ export { default as PlusIcon } from './PlusIcon';
 export { default as BathRoomIcon } from './BathRoomIcon';
 export { default as BedRoomIcon } from './BedRoomIcon';
 export { default as EtcIcon } from './EtcIcon';
-export { default as LivingRoom } from './LivingRoom';
+export { default as LivingRoomIcon } from './LivingRoomIcon';
 export { default as KitchenIcon } from './KitchenIcon';
 export { default as OutIcon } from './OutIcon';
 export { default as MetalIcon } from './MetalIcon';

--- a/src/components/common/tab/PresetTab/PresetTab.tsx
+++ b/src/components/common/tab/PresetTab/PresetTab.tsx
@@ -48,14 +48,13 @@ const PresetTab: React.FC<PresetTabProps> = ({
 
   return (
     <Tabs defaultValue={PresetCategory.ALL}>
-      <TabsList className='flex w-full justify-start gap-4 overflow-x-auto overflow-y-hidden bg-white03 p-0 px-5 no-scrollbar'>
-        <PresetTabItem name={allPresetData.category} value={allPresetData.category} icon='' />
+      <TabsList className='flex h-full w-full justify-start gap-4 overflow-x-auto bg-white03 p-0 px-5 no-scrollbar'>
+        <PresetTabItem name={allPresetData.category} value={allPresetData.category} />
         {presetData.map(categoryList => (
           <PresetTabItem
             key={categoryList.presetCategoryId}
             name={categoryList.category}
             value={categoryList.category}
-            icon=''
           />
         ))}
       </TabsList>

--- a/src/components/common/tab/PresetTab/PresetTabItem.tsx
+++ b/src/components/common/tab/PresetTab/PresetTabItem.tsx
@@ -1,19 +1,34 @@
+import {
+  BathRoomIcon,
+  BedRoomIcon,
+  EtcIcon,
+  HomeIcon,
+  KitchenIcon,
+  LivingRoomIcon,
+} from '@/components/common/icon';
 import { TabsTrigger } from '@/components/common/ui/tabs';
+import { Category } from '@/constants';
 
 interface PresetTabItemProps {
   name: string;
   value: string;
-  icon: string;
 }
 
-const PresetTabItem: React.FC<PresetTabItemProps> = ({ name, value, icon }) => {
+const PresetTabItem: React.FC<PresetTabItemProps> = ({ name, value }) => {
   return (
     <TabsTrigger
       value={value}
-      className='flex gap-2 rounded-xl px-4 py-[6px] text-14 data-[state=active]:bg-black01 data-[state=inactive]:bg-white02 data-[state=active]:text-white03'
+      className='font-label data-[state=active]:bg-black data-[state=inactive]:bg-gray4 data-[state=active]:text-white data-[state=inactive]:text-black flex gap-2 rounded-xl px-2 py-2'
     >
-      {name !== '전체' && <div className='h-5 w-5 bg-gray03'>{icon}</div>}
-      {name}
+      <div className='flex h-5 items-center justify-center'>
+        {name === Category.ALL && <HomeIcon />}
+        {name === Category.LIVING_ROOM && <LivingRoomIcon />}
+        {name === Category.BATH_ROOM && <BathRoomIcon />}
+        {name === Category.BED_ROOM && <BedRoomIcon />}
+        {name === Category.KITCHEN && <KitchenIcon />}
+        {name === Category.ETC && <EtcIcon />}
+      </div>
+      <span className='flex items-center'>{name}</span>
     </TabsTrigger>
   );
 };

--- a/src/components/common/tag/HouseworkCatetoryTag/HouseworkCategoryTag.tsx
+++ b/src/components/common/tag/HouseworkCatetoryTag/HouseworkCategoryTag.tsx
@@ -4,10 +4,13 @@ export interface HouseworkCategoryTagProps {
   /** 집안일 카테고리 */
   category: string;
   /** 상태 */
-  variant: 'primary' | 'secondary' | 'disabled' | 'grayfill' | 'darkfill';
+  variant?: 'primary' | 'secondary' | 'disabled' | 'grayfill' | 'darkfill';
 }
 
-const HouseworkCategoryTag: React.FC<HouseworkCategoryTagProps> = ({ category, variant }) => {
+const HouseworkCategoryTag: React.FC<HouseworkCategoryTagProps> = ({
+  category,
+  variant = 'primary',
+}) => {
   return (
     <div>
       <Badge variant={variant}>{category}</Badge>


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약

- 아이콘태그 스타일링 추가

## 📌 이슈 넘버

- #470 

## 📝 작업 내용
- 아이콘태그 스타일링 추가
- LivingRoom -> LivingRoomIcon 으로 이름 통일

## 📸 스크린샷(선택)
![image](https://github.com/user-attachments/assets/0b1d2c5a-8e2d-4fc1-bce2-891680ad7914)
![image](https://github.com/user-attachments/assets/5dcdc353-61db-4b1d-a294-90984755fa58)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
