### PR TITLE
Feature/#502 - 초대 링크 컴포넌트 아이콘 색깔 수정

### DIFF
--- a/src/components/setting/groupSetting/InviteLink/InviteLink.tsx
+++ b/src/components/setting/groupSetting/InviteLink/InviteLink.tsx
@@ -33,7 +33,7 @@ const InviteLink: React.FC<InviteLinkProps> = ({ initialLink }) => {
     <div className='flex h-14 items-center justify-between gap-4 border-b-2 border-solid border-gray5 border-opacity-30 bg-white px-2 text-gray2 font-label'>
       {inviteLink ? (
         <>
-          <LinkIcon fillClass='fill-gray2' />
+          <LinkIcon className='fill-gray2' />
           <div className='min-w-0 flex-1 overflow-hidden'>
             <p className='truncate text-gray2'>{inviteLink}</p>
           </div>


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약

> 초대 링크 컴포넌트 아이콘 색깔 수정

## 📌 이슈 넘버

> #502

## 📝 작업 내용
- 초대 링크 컴포넌트 아이콘 색깔 수정

## 📸 스크린샷(선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
