### PR TITLE
Feature/#537 - 주간 통계가 미래로 못 가게 버튼 막기

### DIFF
--- a/src/components/statistics/weekly/WeeklyStatDate/WeeklyStatDate.tsx
+++ b/src/components/statistics/weekly/WeeklyStatDate/WeeklyStatDate.tsx
@@ -36,14 +36,16 @@ const WeeklyStatDate: React.FC<WeeklyStatDateProps> = ({
     return `${year}년 ${new Intl.DateTimeFormat('ko-KR', { month: 'long' }).format(date)} ${weekLabels[weekNumber]}`;
   };
 
+  const isCurrentDateFuture = currentDate > new Date();
+
   return (
     <div className='mb-4 flex items-center justify-center gap-8'>
       <button onClick={handlePrevWeek}>
         <ArrowLeftIcon className='text-gray1' />
       </button>
       <span className='text-gray font-subhead'>{getWeekText(currentDate)}</span>
-      <button onClick={handleNextWeek}>
-        <ArrowRightIcon className='text-gray1' />
+      <button onClick={handleNextWeek} disabled={isCurrentDateFuture}>
+        <ArrowRightIcon className={`text-gray1 ${isCurrentDateFuture ? 'opacity-30' : ''}`} />
       </button>
     </div>
   );


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약

> 주간 통계가 미래로 못 가게 버튼 막기

## 📌 이슈 넘버

> #537

## 📝 작업 내용
- 버튼 막았습니다

## 📸 스크린샷(선택)
![image](https://github.com/user-attachments/assets/8ff83af3-f9ef-409b-aff6-68778d2b4488)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
