### PR TITLE
Feature/#529-프리셋 사용자정의 selectedItem 추가 & 삭제컨트롤 로직 수정

### DIFF
--- a/src/components/common/preset/PresetItem.tsx
+++ b/src/components/common/preset/PresetItem.tsx
@@ -1,3 +1,4 @@
+import { BinIcon } from '@/components/common/icon';
 import HouseworkCategoryTag, {
   HouseworkCategoryTagProps,
 } from '@/components/common/tag/HouseworkCatetoryTag/HouseworkCategoryTag';
@@ -20,7 +21,6 @@ const PresetItem: React.FC<PresetItemProps> = ({
   handleSelectClick,
   isPresetSettingCustom,
   isShowDeleteBtn,
-  handleSettingClick,
   handleDeleteClick,
   isSelected,
   isBottomSheet,
@@ -29,7 +29,7 @@ const PresetItem: React.FC<PresetItemProps> = ({
     <li
       className={`flex flex-1 cursor-pointer list-none items-center justify-between border-b-[1px] border-solid border-white pl-5 ${
         isBottomSheet ? 'p-5' : 'p-4'
-      }`}
+      } ${!isBottomSheet && isShowDeleteBtn ? 'box-border bg-sub2' : ''}`}
       onClick={handleSelectClick}
     >
       <div className='flex items-center'>
@@ -38,14 +38,10 @@ const PresetItem: React.FC<PresetItemProps> = ({
       </div>
       {isPresetSettingCustom && (
         <div className='flex items-center'>
-          {isShowDeleteBtn ? (
-            <button className='bg-gray4 text-14' onClick={handleDeleteClick}>
-              삭제
+          {isShowDeleteBtn && (
+            <button onClick={handleDeleteClick}>
+              <BinIcon />
             </button>
-          ) : (
-            <div className='text-14'>
-              <button onClick={handleSettingClick}>선택</button>
-            </div>
           )}
         </div>
       )}

--- a/src/components/common/tab/PresetTab/PresetTab.tsx
+++ b/src/components/common/tab/PresetTab/PresetTab.tsx
@@ -22,7 +22,6 @@ interface PresetTabProps {
   presetData: PresetList[];
   isPresetSettingCustom?: boolean;
   deleteButtonStates?: Record<number, boolean>;
-  handleSettingClick?: (itemId: number) => void;
   handleDeleteClick?: (itemId: number) => void;
   isBottomSheet?: boolean;
   handleClick?: (id: number, description: string, category: string) => void;
@@ -33,7 +32,6 @@ const PresetTab: React.FC<PresetTabProps> = ({
   presetData,
   isPresetSettingCustom = false,
   deleteButtonStates = {},
-  handleSettingClick,
   handleDeleteClick,
   isBottomSheet = false,
   handleClick,
@@ -74,9 +72,6 @@ const PresetTab: React.FC<PresetTabProps> = ({
               isBottomSheet={isBottomSheet}
               isPresetSettingCustom={isPresetSettingCustom}
               isShowDeleteBtn={deleteButtonStates[item.presetItemId]} //각 아이템의 boolean값이 들어간다.
-              handleSettingClick={
-                handleSettingClick && (() => handleSettingClick(item.presetItemId))
-              }
               handleDeleteClick={handleDeleteClick && (() => handleDeleteClick(item.presetItemId))}
               isSelected={selectedItem === item.presetItemId}
             />
@@ -101,9 +96,6 @@ const PresetTab: React.FC<PresetTabProps> = ({
                 isBottomSheet={isBottomSheet}
                 isPresetSettingCustom={isPresetSettingCustom}
                 isShowDeleteBtn={deleteButtonStates[item.presetItemId]} //각 아이템의 boolean값이 들어간다.
-                handleSettingClick={
-                  handleSettingClick && (() => handleSettingClick(item.presetItemId))
-                }
                 handleDeleteClick={
                   handleDeleteClick && (() => handleDeleteClick(item.presetItemId))
                 }

--- a/src/hooks/usePresetSetting.ts
+++ b/src/hooks/usePresetSetting.ts
@@ -11,8 +11,14 @@ import { PresetDefault, PresetTabName } from '@/constants';
 
 const usePresetSetting = () => {
   const navigate = useNavigate();
-  const { setCategoryList, setDeleteButtonStates, activeTab, setPresetData } =
-    usePresetSettingStore();
+  const {
+    setCategoryList,
+    setDeleteButtonStates,
+    activeTab,
+    setPresetData,
+    selectedItem,
+    setSelectedItem,
+  } = usePresetSettingStore();
   const { channelId: strChannelId } = useParams();
   const channelId = Number(strChannelId);
 
@@ -62,18 +68,14 @@ const usePresetSetting = () => {
     }
   };
 
-  const handleSettingClick = (itemId: number) => {
-    setDeleteButtonStates(prev => ({
-      ...prev,
-      [itemId]: true,
-    }));
+  const handleSelectClick = (presetItemId: number) => {
+    const isDeselecting = selectedItem === presetItemId;
+    setSelectedItem(isDeselecting ? null : presetItemId);
+    setDeleteButtonStates(isDeselecting ? null : presetItemId);
   };
 
   const handleDeleteClick = async (presetItemId: number) => {
-    setDeleteButtonStates(prev => ({
-      ...prev,
-      [presetItemId]: false,
-    }));
+    setDeleteButtonStates(null);
 
     try {
       await deletePresetItem({ channelId, presetItemId });
@@ -90,7 +92,7 @@ const usePresetSetting = () => {
 
   return {
     handleAddInput,
-    handleSettingClick,
+    handleSelectClick,
     handleDeleteClick,
     handleBack,
   };

--- a/src/pages/PresetSettingPage.tsx
+++ b/src/pages/PresetSettingPage.tsx
@@ -10,7 +10,7 @@ import usePresetSettingStore from '@/store/usePresetSettingStore';
 const PresetSettingPage = () => {
   const { categoryList, activeTab, setActiveTab, deleteButtonStates, presetData } =
     usePresetSettingStore();
-  const { handleAddInput, handleSettingClick, handleDeleteClick, handleBack } = usePresetSetting();
+  const { handleAddInput, handleSelectClick, handleDeleteClick, handleBack } = usePresetSetting();
 
   return (
     <div className='flex min-h-screen flex-col'>
@@ -29,8 +29,8 @@ const PresetSettingPage = () => {
               presetData={presetData}
               isPresetSettingCustom={true}
               deleteButtonStates={deleteButtonStates}
-              handleSettingClick={handleSettingClick}
               handleDeleteClick={handleDeleteClick}
+              handleClick={handleSelectClick}
             />
           </div>
           <div className='sticky bottom-0 bg-[#fff]'>

--- a/src/store/usePresetSettingStore.ts
+++ b/src/store/usePresetSettingStore.ts
@@ -36,12 +36,13 @@ interface PresetState {
   setActiveInputCateId: (activeInputTabId: number) => void;
   // 삭제버튼
   deleteButtonStates: Record<number, boolean>;
-  setDeleteButtonStates: (
-    updateFn: (prevState: Record<number, boolean>) => Record<number, boolean>
-  ) => void;
+  setDeleteButtonStates: (activeItemId: number | null) => void;
   // 프리셋 리스트 데이터
   presetData: PresetList[];
   setPresetData: (presetData: PresetList[]) => void;
+  // 선택한 아이템
+  selectedItem: number | null;
+  setSelectedItem: (itemId: number | null) => void;
 }
 
 const usePresetSettingStore = create<PresetState>(set => ({
@@ -60,10 +61,14 @@ const usePresetSettingStore = create<PresetState>(set => ({
   activeInputCateId: 0,
   setActiveInputCateId: activeInputCateId => set({ activeInputCateId }),
   deleteButtonStates: {},
-  setDeleteButtonStates: updateFn =>
-    set(state => ({ deleteButtonStates: updateFn(state.deleteButtonStates) })),
+  setDeleteButtonStates: activeItemId =>
+    set(() => ({
+      deleteButtonStates: activeItemId ? { [activeItemId]: true } : {},
+    })),
   presetData: [],
   setPresetData: (presetData: PresetList[]) => set({ presetData }),
+  selectedItem: null,
+  setSelectedItem: selectedItem => set({ selectedItem }),
 }));
 
 export default usePresetSettingStore;


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약

- 프리셋 사용자정의 selectedItem 추가 & 삭제컨트롤 로직 수정

## 📌 이슈 넘버

- #529 

## 📝 작업 내용
- 프리셋 사용자정의 selectedItem 추가 & 삭제컨트롤 로직 수정
- 프리셋 리스트 스타일 수정

## 📸 스크린샷(선택)
![image](https://github.com/user-attachments/assets/45009812-e16f-4195-8f16-da8b3a91bd25)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
