### PR TITLE
Feature/#433-주간통계 랭킹 api 연동 & 프로필이미지 적용

### DIFF
--- a/src/components/statistics/weekly/WeeklyRanking/WeeklyOthers/WeeklyOthers.tsx
+++ b/src/components/statistics/weekly/WeeklyRanking/WeeklyOthers/WeeklyOthers.tsx
@@ -1,21 +1,28 @@
 import React from 'react';
-import { MemberScoreCount } from '@/components/statistics/weekly/WeeklyRanking/WeeklyRanking';
+import { WeeklyMemberScore } from '@/store/useWeeklyStatisticsStore';
 
-interface WeeklyOthersProps extends MemberScoreCount {
+interface WeeklyOthersProps extends WeeklyMemberScore {
   rank: number;
 }
 
-const WeeklyOthers: React.FC<WeeklyOthersProps> = ({ rank, nickname, completeCount }) => {
-  // TODO 프로필 이미지 저장 후 변경
-  const profile = `https://fakeimg.pl/200x200/1FCFBA,128/000,255?text=Doto`;
+const WeeklyOthers: React.FC<WeeklyOthersProps> = ({
+  rank,
+  nickName,
+  profileImageUrl,
+  completeCount,
+}) => {
   return (
     <div className='flex items-center justify-between text-gray3 font-body'>
       <div className='flex items-center gap-2'>
         <p>{rank}</p>
-        <div className='flex h-8 w-8 items-center justify-center overflow-hidden rounded-full border border-solid'>
-          <img src={profile} alt='' />
+        <div className='flex h-8 w-8 items-center justify-center overflow-hidden rounded-full'>
+          <img
+            className='h-full w-full rounded-full object-cover'
+            src={profileImageUrl}
+            alt='프로필 이미지'
+          />
         </div>
-        <p>{nickname}</p>
+        <p className='text-gray3 font-body'>{nickName}</p>
       </div>
       <p>{completeCount}개</p>
     </div>

--- a/src/components/statistics/weekly/WeeklyRanking/WeeklyPodium/WeeklyPodium.tsx
+++ b/src/components/statistics/weekly/WeeklyRanking/WeeklyPodium/WeeklyPodium.tsx
@@ -1,21 +1,28 @@
 import React from 'react';
-import { MemberScoreCount } from '@/components/statistics/weekly/WeeklyRanking/WeeklyRanking';
+import { WeeklyMemberScore } from '@/store/useWeeklyStatisticsStore';
 
-interface WeeklyPodiumProps extends MemberScoreCount {
+interface WeeklyPodiumProps extends WeeklyMemberScore {
   rank: number;
 }
 
-const WeeklyPodium: React.FC<WeeklyPodiumProps> = ({ rank, nickname, completeCount }) => {
-  // TODO 프로필 이미지 저장 후 변경
-  const profile = `https://fakeimg.pl/200x200/1FCFBA,128/000,255?text=Doto`;
+const WeeklyPodium: React.FC<WeeklyPodiumProps> = ({
+  rank,
+  nickName,
+  completeCount,
+  profileImageUrl,
+}) => {
   return (
     <div
       className={`flex flex-col items-center justify-center gap-2 ${rank === 2 && 'order-first'}`}
     >
       <div
-        className={`relative ${rank === 1 ? 'h-24 w-24' : 'h-16 w-16'} flex items-center justify-center rounded-full border border-solid`}
+        className={`relative ${rank === 1 ? 'h-24 w-24' : 'h-16 w-16'} flex items-center justify-center rounded-full border`}
       >
-        <img src={profile} alt='profile' className='w-full rounded-full' />
+        <img
+          src={profileImageUrl}
+          alt='profile'
+          className='h-full w-full rounded-full object-cover'
+        />
         <div
           className={`absolute ${rank === 1 ? '-left-0' : '-left-2'} top-0 flex h-6 w-6 items-center justify-center rounded-full ${
             rank === 1 ? 'bg-rank1' : rank === 2 ? 'bg-rank2' : rank === 3 ? 'bg-rank3' : 'bg-gray3'
@@ -24,11 +31,9 @@ const WeeklyPodium: React.FC<WeeklyPodiumProps> = ({ rank, nickname, completeCou
           {rank}
         </div>
       </div>
-      <p>
-        <strong>{nickname}</strong>
-      </p>
+      <p className='font-body'>{nickName}</p>
       <p className='rounded-full bg-main px-3 py-1 text-white font-label'>
-        {completeCount === 0 ? '-' : `${completeCount}개`}
+        {nickName === '-' ? '-' : `${completeCount}개`}
       </p>
     </div>
   );

--- a/src/components/statistics/weekly/WeeklyRanking/WeeklyRanking.tsx
+++ b/src/components/statistics/weekly/WeeklyRanking/WeeklyRanking.tsx
@@ -2,23 +2,16 @@ import React from 'react';
 import WeeklyPodium from '@/components/statistics/weekly/WeeklyRanking/WeeklyPodium/WeeklyPodium';
 import WeeklyOthers from '@/components/statistics/weekly/WeeklyRanking/WeeklyOthers/WeeklyOthers';
 import { Card } from '@/components/common/ui/card';
-
-export interface MemberScoreCount {
-  /** 닉네임 */
-  nickname: string;
-  /** 완료 개수 */
-  completeCount: number;
-}
-
+import { WeeklyMemberScore } from '@/store/useWeeklyStatisticsStore';
 interface WeeklyRankingProps {
-  rankings: Array<MemberScoreCount>;
+  rankings: Array<WeeklyMemberScore>;
 }
 
 const WeeklyRanking: React.FC<WeeklyRankingProps> = ({ rankings }) => {
   const podiumData = [
-    rankings[0] || { nickname: '-', completeCount: 0 },
-    rankings[1] || { nickname: '-', completeCount: 0 },
-    rankings[2] || { nickname: '-', completeCount: 0 },
+    rankings[0] || { nickName: '-', completeCount: '-' },
+    rankings[1] || { nickName: '-', completeCount: '-' },
+    rankings[2] || { nickName: '-', completeCount: '-' },
   ];
 
   return (
@@ -26,7 +19,13 @@ const WeeklyRanking: React.FC<WeeklyRankingProps> = ({ rankings }) => {
       <p className='text-center text-gray font-subhead'>이번주 완료 개수 랭킹</p>
       <div className='flex items-center justify-between font-body'>
         {podiumData.map((ranker, index) => (
-          <WeeklyPodium key={index} rank={index + 1} {...ranker} />
+          <WeeklyPodium
+            key={index}
+            rank={index + 1}
+            nickName={ranker.nickName}
+            profileImageUrl={ranker.profileImageUrl}
+            completeCount={ranker.completeCount}
+          />
         ))}
       </div>
       <div className='flex flex-col justify-center gap-2'>

--- a/src/hooks/useWeeklyStatistics.ts
+++ b/src/hooks/useWeeklyStatistics.ts
@@ -1,5 +1,5 @@
-import { getWeeklyScore } from '@/services/statistics/GetWeeklyScore';
-import { getWeeklyTotalCount } from '@/services/statistics/GetWeeklyTotalCount';
+import { getWeeklyScore } from '@/services/statistics/getWeeklyScore';
+import { getWeeklyTotalCount } from '@/services/statistics/getWeeklyTotalCount';
 import useWeeklyStateStore from '@/store/useWeeklyStatisticsStore';
 import getFormattedDate from '@/utils/getFormattedDate';
 import { useEffect } from 'react';
@@ -14,31 +14,13 @@ const useWeeklyStatistics = () => {
   useEffect(() => {
     // TODO API 개발 후, 주석풀고 임시값 제거
     // getTotalCountData();
-    // getScoreCountData();
+    getScoreCountData();
     setTotalCountData({
       completeCount: 10,
       notCompleteCount: 3,
       complimentCount: 10,
       pokeCount: 3,
     });
-    setScoreCountData([
-      {
-        nickname: '엄마',
-        completeCount: 8,
-      },
-      {
-        nickname: '아빠',
-        completeCount: 6,
-      },
-      {
-        nickname: '첫째',
-        completeCount: 4,
-      },
-      {
-        nickname: '둘째',
-        completeCount: 2,
-      },
-    ]);
   }, []);
 
   const getTotalCountData = async () => {
@@ -61,6 +43,7 @@ const useWeeklyStatistics = () => {
     }
   };
 
+  // TODO Remove
   console.log(getTotalCountData, getScoreCountData);
 
   const handlePrevWeek = () => {

--- a/src/services/statistics/GetWeeklyScore.ts
+++ b/src/services/statistics/GetWeeklyScore.ts
@@ -1,10 +1,11 @@
 import { axiosInstance } from '@/services/axiosInstance';
 import { GetWeeklyScoreReq, GetWeeklyScoreRes } from '@/types/apis/statisticsApi';
 
-export const getWeeklyScore = async (data: GetWeeklyScoreReq) => {
+export const getWeeklyScore = async ({ channelId, targetDate }: GetWeeklyScoreReq) => {
   try {
     const response = await axiosInstance.get<GetWeeklyScoreRes>(
-      `/api/v1/channels/${data.channelId}/statistics/weekly/${data.targetDate}/score`
+      `/api/v1/channels/${channelId}/statistics/weekly/${targetDate}/score`,
+      { params: { targetDate } }
     );
     return response.data;
   } catch (error) {

--- a/src/services/statistics/GetWeeklyTotalCount.ts
+++ b/src/services/statistics/GetWeeklyTotalCount.ts
@@ -1,10 +1,11 @@
 import { axiosInstance } from '@/services/axiosInstance';
 import { GetWeeklyTotalCountReq, GetWeeklyTotalCountRes } from '@/types/apis/statisticsApi';
 
-export const getWeeklyTotalCount = async (data: GetWeeklyTotalCountReq) => {
+export const getWeeklyTotalCount = async ({ channelId, targetDate }: GetWeeklyTotalCountReq) => {
   try {
     const response = await axiosInstance.get<GetWeeklyTotalCountRes>(
-      `/api/v1/channels/${data.channelId}/statistics/weekly/${data.targetDate}/totalCount`
+      `/api/v1/channels/${channelId}/statistics/weekly/${targetDate}/totalCount`,
+      { params: { targetDate } }
     );
     return response.data;
   } catch (error) {

--- a/src/store/useWeeklyStatisticsStore.ts
+++ b/src/store/useWeeklyStatisticsStore.ts
@@ -10,9 +10,11 @@ interface TotalCountData {
   /** 찌르기 개수 */
   pokeCount: number;
 }
-export interface MemberScoreCount {
+export interface WeeklyMemberScore {
   /** 닉네임 */
-  nickname: string;
+  nickName: string;
+  /** 프로필 이미지 URL */
+  profileImageUrl: string;
   /** 완료 개수 */
   completeCount: number;
 }
@@ -25,8 +27,8 @@ interface WeeklyState {
   totalCountData: TotalCountData;
   setTotalCountData: (data: TotalCountData) => void;
   /** 랭킹 카운트 데이터 */
-  scoreCountData: Array<MemberScoreCount>;
-  setScoreCountData: (data: Array<MemberScoreCount>) => void;
+  scoreCountData: Array<WeeklyMemberScore>;
+  setScoreCountData: (data: Array<WeeklyMemberScore>) => void;
 }
 
 const useWeeklyStateStore = create<WeeklyState>(set => ({

--- a/src/types/apis/statisticsApi.ts
+++ b/src/types/apis/statisticsApi.ts
@@ -3,7 +3,9 @@ import { Common } from '@/types/apis/commonApi';
 
 export interface WeeklyMemberScore {
   /** 닉네임 */
-  nickname: string;
+  nickName: string;
+  /** 프로필 이미지 URL */
+  profileImageUrl: string;
   /** 완료 개수 */
   completeCount: number;
 }


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약

- 주간통계 랭킹 api 연동 & 프로필 이미지 적용

## 📌 이슈 넘버

- #433 

## 📝 작업 내용
- 주간통계 랭킹 api 연동
- 프로필 이미지 적용

## 📸 스크린샷(선택)
![image](https://github.com/user-attachments/assets/7b82f309-7cc7-4aa1-9ed2-5704ee352db3)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
