### PR TITLE
Feature/#573 - 바텀 내비게이션 활성화 스타일 변경

### DIFF
--- a/src/components/common/bottomNav/BottomNav.tsx
+++ b/src/components/common/bottomNav/BottomNav.tsx
@@ -12,8 +12,6 @@ const BottomNav = () => {
   const location = useLocation();
   const currentPath = location.pathname;
 
-  console.log(currentPath);
-
   const navItems = [
     {
       name: '홈',
@@ -56,6 +54,7 @@ const BottomNav = () => {
           icon={navItems[0].icon}
           name={navItems[0].name}
           handleClick={() => handleClick(`/main/${channelId}`)}
+          isActive={currentPath === `/main/${channelId}`}
         />
       </div>
       <div className='flex flex-1 justify-center'>
@@ -63,6 +62,7 @@ const BottomNav = () => {
           icon={navItems[1].icon}
           name={navItems[1].name}
           handleClick={() => handleClick(`/main/${channelId}/statistics/weekly`)}
+          isActive={currentPath.includes('statistics')}
         />
       </div>
       <div className='flex flex-1 justify-center'>
@@ -73,6 +73,7 @@ const BottomNav = () => {
           icon={navItems[2].icon}
           name={navItems[2].name}
           handleClick={() => handleClick(`/main/${channelId}/group-setting`)}
+          isActive={currentPath.includes('group-setting')}
         />
       </div>
       <div className='flex flex-1 justify-center'>
@@ -80,6 +81,7 @@ const BottomNav = () => {
           icon={navItems[3].icon}
           name={navItems[3].name}
           handleClick={() => handleClick(`/main/${channelId}/my-page`)}
+          isActive={currentPath.includes('my-page')}
         />
       </div>
     </div>

--- a/src/components/common/bottomNav/BottomNavBtn/BottomNavBtn.tsx
+++ b/src/components/common/bottomNav/BottomNavBtn/BottomNavBtn.tsx
@@ -4,6 +4,7 @@ interface BottomNavBtnProps {
   icon: React.ReactNode;
   name: string;
   handleClick?: () => void;
+  isActive: boolean;
 }
 
 const BottomNavBtn: React.FC<BottomNavBtnProps> = ({
@@ -13,11 +14,13 @@ const BottomNavBtn: React.FC<BottomNavBtnProps> = ({
   name,
   /** click */
   handleClick,
+  /** active */
+  isActive,
 }) => {
   return (
     <button className='flex flex-col items-center gap-1 px-3' onClick={handleClick}>
       {icon}
-      <p className='text-gray3 font-caption'>{name}</p>
+      <p className={`font-caption ${isActive ? 'text-black' : 'text-gray3'}`}>{name}</p>
     </button>
   );
 };


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약

> 바텀 네비게이션 활성화 스타일 변경

## 📌 이슈 넘버

> #573

## 📝 작업 내용
- 바텀 네비게이션 활성화 스타일 변경 (text-color)

## 📸 스크린샷(선택)
![image](https://github.com/user-attachments/assets/321e400d-1a76-45a9-81d4-2c44b6b39cb0)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
