### PR TITLE
Feature/#576-프로필 편집 이미지, 닉네임 조건 처리

### DIFF
--- a/src/components/common/profile/ProfileImg.tsx
+++ b/src/components/common/profile/ProfileImg.tsx
@@ -1,5 +1,6 @@
 import { ProfileIcon } from '@/components/common/icon';
 import { cn } from '@/lib/utils';
+import { useLocation } from 'react-router-dom';
 
 interface ProfileImgProps {
   classname?: string;
@@ -7,7 +8,8 @@ interface ProfileImgProps {
 }
 
 const ProfileImg: React.FC<ProfileImgProps> = ({ classname, imageUrl = '' }) => {
-  // TODO 컴포넌트 역할 분리 (상태, 함수)
+  const location = useLocation();
+  const isEditPage = location.pathname.includes('edit');
 
   return (
     <div className={cn(`relative aspect-square h-36 w-36 overflow-hidden`, classname)}>
@@ -20,8 +22,17 @@ const ProfileImg: React.FC<ProfileImgProps> = ({ classname, imageUrl = '' }) => 
           />
         ) : (
           // TODO 기본 이미지 경로 설정
-          <div className='flex h-20 w-20 items-center justify-center rounded-full bg-sub'>
-            <ProfileIcon className='text-sub2' width={40} height={40} />
+          <div
+            className={cn(
+              'flex items-center justify-center rounded-full bg-sub',
+              isEditPage ? 'h-36 w-36' : 'h-20 w-20'
+            )}
+          >
+            <ProfileIcon
+              className='text-sub2'
+              width={isEditPage ? 70 : 40}
+              height={isEditPage ? 70 : 40}
+            />
           </div>
         )}
       </div>

--- a/src/components/my/ProfileEditBtn/ProfileEditBtn.tsx
+++ b/src/components/my/ProfileEditBtn/ProfileEditBtn.tsx
@@ -1,11 +1,20 @@
 import { useNavigate, useParams } from 'react-router-dom';
 
-const ProfileEditBtn = () => {
+import React from 'react';
+
+interface ProfileEditBtnProps {
+  imageUrl?: string;
+  nickname?: string;
+}
+
+const ProfileEditBtn: React.FC<ProfileEditBtnProps> = ({ imageUrl, nickname }) => {
   const navigate = useNavigate();
   const { channelId } = useParams();
 
   const handleClick = () => {
-    navigate(`/main/${channelId}/my-page/edit`);
+    navigate(`/main/${channelId}/my-page/edit`, {
+      state: { imageUrl, nickname },
+    });
   };
   return (
     <button

--- a/src/pages/MyPage.tsx
+++ b/src/pages/MyPage.tsx
@@ -39,7 +39,7 @@ const MyPage = () => {
       </div>
       <div className='flex justify-between px-5 pb-3 pt-2'>
         <AccountInfo nickname={myInfo.nickName} account={myInfo.email} />
-        <ProfileEditBtn />
+        <ProfileEditBtn nickname={myInfo.nickName} imageUrl={myInfo.profileImageUrl} />
       </div>
       <div className='px-5'>
         <div className='mb-6 mt-2 h-[1px] w-full bg-gray5' />

--- a/src/pages/MyPageEditPage.tsx
+++ b/src/pages/MyPageEditPage.tsx
@@ -2,12 +2,16 @@ import Header from '@/components/common/header/Header';
 import InputWithLabel from '@/components/common/input/InputWithLabel';
 import ProfileImg from '@/components/common/profile/ProfileImg';
 import { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import { useParams } from 'react-router-dom';
 
 const MyPageEditPage = () => {
   const navigate = useNavigate();
-  const [username, setUserName] = useState<string>(''); // 수정
+  const location = useLocation();
+  const imageUrl = location.state?.imageUrl;
+  const nickName = location.state?.nickname;
+
+  const [username, setUserName] = useState<string>(nickName); // 수정
   const { channelId } = useParams();
   const handleBack = () => {
     navigate(`/main/${channelId}/my-page`);
@@ -15,9 +19,9 @@ const MyPageEditPage = () => {
   return (
     <>
       <Header title='프로필 편집' isNeededDoneBtn={false} handleBack={handleBack} />
-      <div className='mt-10 flex flex-col gap-14 px-5'>
+      <div className='mt-10 flex flex-col gap-12 px-5'>
         <div className='m-auto'>
-          <ProfileImg />
+          <ProfileImg imageUrl={imageUrl} />
         </div>
         <InputWithLabel label='이름' value={username} disabled={false} handleChange={setUserName} />
       </div>


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약

> 이미지 있을 땐 프로필 이미지가 보이도록
없을땐 그냥 기본 이미지가 보이도록, 그리고 닉네임이 에딧페이지에 뜨도록 수정했습니다.

## 📌 이슈 넘버

> ex) #이슈번호, #이슈번호

#576 

## 📝 작업 내용

## 📸 스크린샷(선택)

![image](https://github.com/user-attachments/assets/5a3e0d52-d982-4539-9df6-2dda2f0d4a00)
![image](https://github.com/user-attachments/assets/0edb52ef-8117-49f1-9a53-aa8401fc823c)


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
