### PR TITLE
Feature/#433-주간통계 api 연동 및 데이터 처리

### DIFF
--- a/src/components/common/icon/IconView.tsx
+++ b/src/components/common/icon/IconView.tsx
@@ -34,6 +34,10 @@ import {
   MonthlyHeartIcon,
   MonthFingerIcon,
   TrashCanIcon,
+  BroomDustIcon,
+  BubbleIcon,
+  ShinyIcon,
+  ProfileDefaultIcon,
 } from '@/components/common/icon';
 import EnterIcon from '@/components/common/icon/EnterIcon';
 
@@ -175,14 +179,30 @@ const IconView = () => {
       <div className='flex flex-col items-center gap-2'>
         <p className='text-sm text-gray-600'>MonthlyHeartIcon</p>
         <MonthlyHeartIcon />
-        <div className='flex flex-col items-center gap-2'>
-          <p className='text-sm text-gray-600'>EnterIcon</p>
-          <EnterIcon />
-        </div>
+      </div>
+      <div className='flex flex-col items-center gap-2'>
+        <p className='text-sm text-gray-600'>EnterIcon</p>
+        <EnterIcon />
       </div>
       <div className='flex flex-col items-center gap-2'>
         <p className='text-sm text-gray-600'>TrashCanIcon</p>
         <TrashCanIcon />
+      </div>
+      <div className='flex flex-col items-center gap-2'>
+        <p className='text-sm text-gray-600'>BroomDustIcon</p>
+        <BroomDustIcon />
+      </div>
+      <div className='flex flex-col items-center gap-2'>
+        <p className='text-sm text-gray-600'>BubbleIcon</p>
+        <BubbleIcon />
+      </div>
+      <div className='flex flex-col items-center gap-2'>
+        <p className='text-sm text-gray-600'>ShinyIcon</p>
+        <ShinyIcon />
+      </div>
+      <div className='flex flex-col items-center gap-2'>
+        <p className='text-sm text-gray-600'>ProfileDefaultIcon</p>
+        <ProfileDefaultIcon />
       </div>
     </div>
   );

--- a/src/components/common/icon/NoListIcon.tsx
+++ b/src/components/common/icon/NoListIcon.tsx
@@ -46,15 +46,15 @@ const NoListIcon: React.FC<NoListIconProps> = ({}) => {
           d='M160.4 83.1714C160.4 89.8034 155.024 95.1798 148.392 95.1798C141.76 95.1798 136.383 89.8034 136.383 83.1714C136.383 76.5394 141.76 71.1631 148.392 71.1631C155.024 71.1631 160.4 76.5394 160.4 83.1714Z'
           fill='#CECECE'
           stroke='#CECECE'
-          stroke-width='2.2'
-          stroke-linecap='round'
+          strokeWidth='2.2'
+          strokeLinecap='round'
           stroke-linejoin='round'
         />
         <path
           d='M148.391 76.6182V83.1723L152.76 85.3571'
           stroke='#F2F3F6'
-          stroke-width='2'
-          stroke-linecap='round'
+          strokeWidth='2'
+          strokeLinecap='round'
           stroke-linejoin='round'
         />
         <path

--- a/src/components/common/icon/ProfileDefaultIcon.tsx
+++ b/src/components/common/icon/ProfileDefaultIcon.tsx
@@ -1,0 +1,38 @@
+interface ProfileDefaultIconProps {
+  width?: string | number;
+  height?: string | number;
+}
+
+const ProfileDefaultIcon: React.FC<ProfileDefaultIconProps> = ({ width = 96, height = 96 }) => {
+  return (
+    <svg
+      width={width}
+      height={height}
+      viewBox='0 0 96 96'
+      fill='none'
+      xmlns='http://www.w3.org/2000/svg'
+    >
+      <g clipPath='url(#clip0_2622_21730)'>
+        <path
+          d='M96 48C96 21.4903 74.5097 0 48 0C21.4903 0 0 21.4903 0 48C0 74.5097 21.4903 96 48 96C74.5097 96 96 74.5097 96 48Z'
+          fill='#C6C8D0'
+        />
+        <path
+          d='M48.0003 47.3013C52.3842 47.3013 55.9381 43.7475 55.9381 39.3636C55.9381 34.9796 52.3842 31.4258 48.0003 31.4258C43.6164 31.4258 40.0625 34.9796 40.0625 39.3636C40.0625 43.7475 43.6164 47.3013 48.0003 47.3013Z'
+          fill='#F2F3F6'
+        />
+        <path
+          d='M33.7109 61.9756C33.7109 54.8008 39.5274 48.9844 46.7023 48.9844H49.2956C56.4706 48.9844 62.2869 54.8008 62.2869 61.9756C62.2869 63.4106 61.1237 64.5739 59.6887 64.5739H36.3092C34.8742 64.5739 33.7109 63.4106 33.7109 61.9756Z'
+          fill='#F2F3F6'
+        />
+      </g>
+      <defs>
+        <clipPath id='clip0_2622_21730'>
+          <rect width={width} height={height} fill='white' />
+        </clipPath>
+      </defs>
+    </svg>
+  );
+};
+
+export default ProfileDefaultIcon;

--- a/src/components/common/icon/ShinyIcon.tsx
+++ b/src/components/common/icon/ShinyIcon.tsx
@@ -52,24 +52,24 @@ const ShinyIcon: React.FC<ShinyIconProps> = ({ width = 98, height = 96, classNam
           d='M24.2935 39.781V47.0225V54.2639C24.2929 54.2722 24.2929 54.2791 24.2935 54.2846V54.2639C24.3298 53.7997 26.3774 48.8968 28.5685 47.0225C26.3774 45.1483 24.3298 40.2452 24.2935 39.781ZM24.2926 39.7603C24.2932 39.7658 24.2941 39.7726 24.2935 39.781L24.2926 39.7603ZM24.2935 47.0225V39.781C24.2572 40.2451 22.2086 45.1481 20.0176 47.0225C22.2086 48.8968 24.2572 53.7997 24.2935 54.2639V54.2846C24.2929 54.2791 24.2929 54.2722 24.2935 54.2639V47.0225Z'
           fill='#1FCFBA'
         />
-        <path d='M64.7031 32.2588L70.6551 41.8241' stroke='#8DE8D7' stroke-linecap='round' />
+        <path d='M64.7031 32.2588L70.6551 41.8241' stroke='#8DE8D7' strokeLinecap='round' />
         <path
           d='M39.168 16.6714L43.7538 24.4741'
           stroke='#8DE8D7'
-          stroke-width='0.7'
-          stroke-linecap='round'
+          strokeWidth='0.7'
+          strokeLinecap='round'
         />
         <path
           d='M24.625 43.4927L25.7042 45.4916'
           stroke='#8DE8D7'
-          stroke-width='0.5'
-          stroke-linecap='round'
+          strokeWidth='0.5'
+          strokeLinecap='round'
         />
         <path
           d='M41.6504 58.9673L45.8627 66.3545'
           stroke='#8DE8D7'
-          stroke-width='0.7'
-          stroke-linecap='round'
+          strokeWidth='0.7'
+          strokeLinecap='round'
         />
       </g>
     </svg>

--- a/src/components/common/icon/index.ts
+++ b/src/components/common/icon/index.ts
@@ -36,3 +36,4 @@ export { default as TrashCanIcon } from './TrashCanIcon';
 export { default as BroomDustIcon } from './BroomDustIcon';
 export { default as BubbleIcon } from './BubbleIcon';
 export { default as ShinyIcon } from './ShinyIcon';
+export { default as ProfileDefaultIcon } from './ProfileDefaultIcon';

--- a/src/components/statistics/weekly/WeeklyCompletion/CompletionBarGraph/CompletionBarGraph.tsx
+++ b/src/components/statistics/weekly/WeeklyCompletion/CompletionBarGraph/CompletionBarGraph.tsx
@@ -2,15 +2,12 @@ import React from 'react';
 import { Progress } from '@/components/common/ui/progress';
 
 interface CompletionBarGraphProps {
-  /** 완료된 개수 */
-  completed: number;
-  /** 미완료된 개수 */
-  notCompleted: number;
+  completionRate: number;
 }
 
-const CompletionBarGraph: React.FC<CompletionBarGraphProps> = ({ completed, notCompleted }) => {
-  const total = completed + notCompleted;
-  const completionRate = total > 0 ? (completed / total) * 100 : 0; // 완료율 계산
+const CompletionBarGraph: React.FC<CompletionBarGraphProps> = ({ completionRate }) => {
+  // const total = completed + notCompleted;
+  // const completionRate = total > 0 ? (completed / total) * 100 : 0; // 완료율 계산
 
   return (
     <div>

--- a/src/components/statistics/weekly/WeeklyCompletion/WeeklyCompletion.tsx
+++ b/src/components/statistics/weekly/WeeklyCompletion/WeeklyCompletion.tsx
@@ -3,23 +3,19 @@ import TextTag from '@/components/common/tag/TextTag/TextTag';
 import CompletionText from '@/components/statistics/weekly/WeeklyCompletion/CompletionText/CompletionText';
 import CompletionBarGraph from '@/components/statistics/weekly/WeeklyCompletion/CompletionBarGraph/CompletionBarGraph';
 import { Card } from '@/components/common/ui/card';
-import { TrashCanIcon, BroomDustIcon, BubbleIcon, ShinyIcon } from '@/components/common/icon';
+import { WeeklyTotalCount } from '@/store/useWeeklyStatisticsStore';
+import { WEEKLY_STAT_STEP } from '@/constants';
 
-interface WeeklyCompletionProps {
-  /** 그룹명 */
-  groupName: string;
-  // status: string; // 추후 상태에 따라 아이콘 변경
-  /** 완료된 집안일 개수 */
-  completed: number;
-  /** 미완료된 집안일 개수 */
-  notCompleted: number;
-}
+const WeeklyCompletion: React.FC<
+  Pick<WeeklyTotalCount, 'channelName' | 'completeCount' | 'unCompletedCount'>
+> = ({ channelName, completeCount, unCompletedCount }) => {
+  const totalCount = completeCount + unCompletedCount;
+  const completionRate = totalCount > 0 ? (completeCount / totalCount) * 100 : 0; // 완료율 계산
 
-const WeeklyCompletion: React.FC<WeeklyCompletionProps> = ({
-  groupName,
-  completed,
-  notCompleted,
-}) => {
+  const currentStep = WEEKLY_STAT_STEP.find(
+    step => completionRate >= step.range[0] && completionRate <= step.range[1]
+  );
+
   return (
     <Card className='mb-4 border-none px-5 pb-4 shadow-none'>
       <div className='flex w-full items-center justify-between py-5 pl-5'>
@@ -27,24 +23,21 @@ const WeeklyCompletion: React.FC<WeeklyCompletionProps> = ({
           <div className='flex items-center gap-2'>
             <TextTag
               type='grayfill'
-              className='bg-gray5 px-1.5 py-1 text-black'
-              label={groupName}
+              className='bg-gray1 px-1.5 py-1 text-white'
+              label={channelName}
             />
             <p className='text-black font-subhead'>단계는?</p>
           </div>
-          <p className='text-main font-head'>쓰레기통</p>
+          <p className='text-main font-head'>{currentStep?.name}</p>
           <div className='flex gap-2'>
-            <CompletionText completedText='완료' num={completed} />
-            <CompletionText completedText='미완료' num={notCompleted} />
+            <CompletionText completedText='완료' num={completeCount} />
+            <CompletionText completedText='미완료' num={unCompletedCount} />
           </div>
         </div>
-        <TrashCanIcon />
-        {/* <BroomDustIcon /> */}
-        {/* <BubbleIcon /> */}
-        {/* <ShinyIcon /> */}
+        {currentStep?.icon && <currentStep.icon />}
       </div>
       <div>
-        <CompletionBarGraph completed={completed} notCompleted={notCompleted} />
+        <CompletionBarGraph completionRate={completionRate} />
       </div>
     </Card>
   );

--- a/src/components/statistics/weekly/WeeklyRanking/WeeklyPodium/WeeklyPodium.tsx
+++ b/src/components/statistics/weekly/WeeklyRanking/WeeklyPodium/WeeklyPodium.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { WeeklyMemberScore } from '@/store/useWeeklyStatisticsStore';
+import { ProfileDefaultIcon } from '@/components/common/icon';
 
 interface WeeklyPodiumProps extends WeeklyMemberScore {
   rank: number;
@@ -18,11 +19,15 @@ const WeeklyPodium: React.FC<WeeklyPodiumProps> = ({
       <div
         className={`relative ${rank === 1 ? 'h-24 w-24' : 'h-16 w-16'} flex items-center justify-center rounded-full border`}
       >
-        <img
-          src={profileImageUrl}
-          alt='profile'
-          className='h-full w-full rounded-full object-cover'
-        />
+        {profileImageUrl ? (
+          <img
+            src={profileImageUrl}
+            alt='profile'
+            className='h-full w-full rounded-full object-cover'
+          />
+        ) : (
+          <ProfileDefaultIcon />
+        )}
         <div
           className={`absolute ${rank === 1 ? '-left-0' : '-left-2'} top-0 flex h-6 w-6 items-center justify-center rounded-full ${
             rank === 1 ? 'bg-rank1' : rank === 2 ? 'bg-rank2' : rank === 3 ? 'bg-rank3' : 'bg-gray3'
@@ -31,7 +36,7 @@ const WeeklyPodium: React.FC<WeeklyPodiumProps> = ({
           {rank}
         </div>
       </div>
-      <p className='font-body'>{nickName}</p>
+      <p className='text-black font-body'>{nickName}</p>
       <p className='rounded-full bg-main px-3 py-1 text-white font-label'>
         {nickName === '-' ? '-' : `${completeCount}개`}
       </p>

--- a/src/components/statistics/weekly/WeeklyRanking/WeeklyRanking.tsx
+++ b/src/components/statistics/weekly/WeeklyRanking/WeeklyRanking.tsx
@@ -16,7 +16,7 @@ const WeeklyRanking: React.FC<WeeklyRankingProps> = ({ rankings }) => {
 
   return (
     <Card className='flex flex-col justify-center gap-8 border-none p-8 shadow-none'>
-      <p className='text-center text-black font-subhead'>이번주 완료 개수 랭킹</p>
+      <p className='text-center text-gray2 font-subhead'>이번주 완료 개수 랭킹</p>
       <div className='flex items-center justify-between font-body'>
         {podiumData.map((ranker, index) => (
           <WeeklyPodium

--- a/src/components/statistics/weekly/WeeklyStatAction/WeeklyStatAction.tsx
+++ b/src/components/statistics/weekly/WeeklyStatAction/WeeklyStatAction.tsx
@@ -12,14 +12,14 @@ interface WeeklyStatActionProps {
 const WeeklyStatAction: React.FC<WeeklyStatActionProps> = ({ type, num }) => {
   return (
     <Card
-      className={`${type === 'compliment' ? 'bg-pink2/20' : 'bg-blue2/20'} flex w-full flex-col gap-2 border-none px-10 py-7 shadow-none`}
+      className={`${type === 'compliment' ? 'bg-pink2/20' : 'bg-blue2/20'} flex w-full flex-col gap-2 border-none px-8 py-7 shadow-none`}
     >
       <div className='flex items-center justify-center gap-2'>
         {type === 'compliment' ? <HeartIcon /> : <FingerIcon />}
         <p className='text-black font-head'>{num}번</p>
       </div>
       <p className='text-center text-black font-label'>
-        {type === 'compliment' ? '칭찬했어요!' : '찔렸어요!'}
+        {type === 'compliment' ? '칭찬했어요!' : '찔렀어요!'}
       </p>
     </Card>
   );

--- a/src/components/statistics/weekly/WeeklyStatAction/WeeklyStatActions.tsx
+++ b/src/components/statistics/weekly/WeeklyStatAction/WeeklyStatActions.tsx
@@ -1,16 +1,15 @@
 import React from 'react';
 import WeeklyStatAction from '@/components/statistics/weekly/WeeklyStatAction/WeeklyStatAction';
+import { WeeklyTotalCount } from '@/store/useWeeklyStatisticsStore';
 
-interface WeeklyStatActionsProps {
-  numOfCompliment: number;
-  numOfTease: number;
-}
-
-const WeeklyStatActions: React.FC<WeeklyStatActionsProps> = ({ numOfCompliment, numOfTease }) => {
+const WeeklyStatActions: React.FC<Pick<WeeklyTotalCount, 'complimentCount' | 'pokeCount'>> = ({
+  complimentCount,
+  pokeCount,
+}) => {
   return (
     <div className='mb-4 flex justify-between gap-3'>
-      <WeeklyStatAction type='compliment' num={numOfCompliment} />
-      <WeeklyStatAction type='tease' num={numOfTease} />
+      <WeeklyStatAction type='compliment' num={complimentCount} />
+      <WeeklyStatAction type='tease' num={pokeCount} />
     </div>
   );
 };

--- a/src/components/statistics/weekly/WeeklyStatDate/WeeklyStatDate.tsx
+++ b/src/components/statistics/weekly/WeeklyStatDate/WeeklyStatDate.tsx
@@ -52,11 +52,11 @@ const WeeklyStatDate: React.FC<WeeklyStatDateProps> = ({
   return (
     <div className='mb-4 flex items-center justify-center gap-8'>
       <button onClick={handlePrevWeek}>
-        <ArrowLeftIcon className='text-gray1' />
+        <ArrowLeftIcon className='text-gray2' />
       </button>
-      <span className='w-44 text-center text-black font-subhead'>{getWeekText(currentDate)}</span>
+      <span className='w-44 text-center text-gray2 font-subhead'>{getWeekText(currentDate)}</span>
       <button onClick={handleNextWeek} disabled={isNextWeekDisabled()}>
-        <ArrowRightIcon className={`text-gray1 ${isNextWeekDisabled() ? 'opacity-30' : ''}`} />
+        <ArrowRightIcon className={`text-gray2 ${isNextWeekDisabled() ? 'opacity-30' : ''}`} />
       </button>
     </div>
   );

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,5 +1,5 @@
-export { Category } from './Category';
-export { PresetTabName } from './TabName';
+export { Category } from './category';
+export { PresetTabName } from './tabName';
 export { PresetDefault } from './PresetDefault';
 export {
   DUMMY_QUESTION_STEP1,
@@ -8,3 +8,4 @@ export {
   DUMMY_QUESTION_STEP4,
   DUMMY_RESULT,
 } from '@/constants/onBoarding';
+export { WEEKLY_STAT_STEP } from '@/constants/weeklyStatStep';

--- a/src/constants/weeklyStatStep.ts
+++ b/src/constants/weeklyStatStep.ts
@@ -1,0 +1,8 @@
+import { TrashCanIcon, BroomDustIcon, BubbleIcon, ShinyIcon } from '@/components/common/icon';
+
+export const WEEKLY_STAT_STEP = [
+  { range: [0, 25], name: '쓰레기통', icon: TrashCanIcon },
+  { range: [26, 50], name: '먼지털기', icon: BroomDustIcon },
+  { range: [51, 75], name: '버블버블', icon: BubbleIcon },
+  { range: [76, 100], name: '반짝반짝', icon: ShinyIcon },
+];

--- a/src/hooks/useWeeklyStatistics.ts
+++ b/src/hooks/useWeeklyStatistics.ts
@@ -12,16 +12,9 @@ const useWeeklyStatistics = () => {
     useWeeklyStateStore();
 
   useEffect(() => {
-    // TODO API 개발 후, 주석풀고 임시값 제거
-    // getTotalCountData();
+    getTotalCountData();
     getScoreCountData();
-    setTotalCountData({
-      completeCount: 10,
-      notCompleteCount: 3,
-      complimentCount: 10,
-      pokeCount: 3,
-    });
-  }, []);
+  }, [currentDate]);
 
   const getTotalCountData = async () => {
     try {
@@ -42,9 +35,6 @@ const useWeeklyStatistics = () => {
       console.error('주간 통계 랭킹 데이터 조회 실패', error);
     }
   };
-
-  // TODO Remove
-  console.log(getTotalCountData, getScoreCountData);
 
   const handlePrevWeek = () => {
     setCurrentDate((prevDate: Date) => {

--- a/src/pages/WeeklyStatisticsPage.tsx
+++ b/src/pages/WeeklyStatisticsPage.tsx
@@ -5,12 +5,10 @@ import WeeklyStatActions from '@/components/statistics/weekly/WeeklyStatAction/W
 import WeeklyRanking from '@/components/statistics/weekly/WeeklyRanking/WeeklyRanking';
 import useWeeklyStateStore from '@/store/useWeeklyStatisticsStore';
 import useWeeklyStatistics from '@/hooks/useWeeklyStatistics';
-import useHomePageStore from '@/store/useHomePageStore';
 
 const WeeklyStatisticsPage: React.FC = () => {
   const { currentDate, totalCountData, scoreCountData } = useWeeklyStateStore();
   const { handlePrevWeek, handleNextWeek } = useWeeklyStatistics();
-  const { currentGroup } = useHomePageStore();
 
   return (
     <>
@@ -20,13 +18,13 @@ const WeeklyStatisticsPage: React.FC = () => {
         handleNextWeek={handleNextWeek}
       />
       <WeeklyCompletion
-        groupName={currentGroup.name}
-        completed={totalCountData.completeCount}
-        notCompleted={totalCountData.notCompleteCount}
+        channelName={totalCountData.channelName}
+        completeCount={totalCountData.completeCount}
+        unCompletedCount={totalCountData.unCompletedCount}
       />
       <WeeklyStatActions
-        numOfCompliment={totalCountData.complimentCount}
-        numOfTease={totalCountData.pokeCount}
+        complimentCount={totalCountData.complimentCount}
+        pokeCount={totalCountData.pokeCount}
       />
       <WeeklyRanking rankings={scoreCountData} />
     </>

--- a/src/services/statistics/GetWeeklyScore.ts
+++ b/src/services/statistics/GetWeeklyScore.ts
@@ -4,7 +4,7 @@ import { GetWeeklyScoreReq, GetWeeklyScoreRes } from '@/types/apis/statisticsApi
 export const getWeeklyScore = async ({ channelId, targetDate }: GetWeeklyScoreReq) => {
   try {
     const response = await axiosInstance.get<GetWeeklyScoreRes>(
-      `/api/v1/channels/${channelId}/statistics/weekly/${targetDate}/score`,
+      `/api/v1/channels/${channelId}/statistics/weekly/score`,
       { params: { targetDate } }
     );
     return response.data;

--- a/src/services/statistics/GetWeeklyTotalCount.ts
+++ b/src/services/statistics/GetWeeklyTotalCount.ts
@@ -4,7 +4,7 @@ import { GetWeeklyTotalCountReq, GetWeeklyTotalCountRes } from '@/types/apis/sta
 export const getWeeklyTotalCount = async ({ channelId, targetDate }: GetWeeklyTotalCountReq) => {
   try {
     const response = await axiosInstance.get<GetWeeklyTotalCountRes>(
-      `/api/v1/channels/${channelId}/statistics/weekly/${targetDate}/totalCount`,
+      `/api/v1/channels/${channelId}/statistics/weekly/totalCount`,
       { params: { targetDate } }
     );
     return response.data;

--- a/src/store/useWeeklyStatisticsStore.ts
+++ b/src/store/useWeeklyStatisticsStore.ts
@@ -1,10 +1,12 @@
 import { create } from 'zustand';
 
-interface TotalCountData {
+export interface WeeklyTotalCount {
+  /** 그룹명 */
+  channelName: string;
   /** 완료 개수 */
   completeCount: number;
   /** 미완료 개수 */
-  notCompleteCount: number;
+  unCompletedCount: number;
   /** 칭찬 개수 */
   complimentCount: number;
   /** 찌르기 개수 */
@@ -24,8 +26,8 @@ interface WeeklyState {
   currentDate: Date;
   setCurrentDate: (updater: (prevDate: Date) => Date) => void;
   /** 완료, 미완료, 칭찬, 찌르기 카운트 데이터 */
-  totalCountData: TotalCountData;
-  setTotalCountData: (data: TotalCountData) => void;
+  totalCountData: WeeklyTotalCount;
+  setTotalCountData: (data: WeeklyTotalCount) => void;
   /** 랭킹 카운트 데이터 */
   scoreCountData: Array<WeeklyMemberScore>;
   setScoreCountData: (data: Array<WeeklyMemberScore>) => void;
@@ -35,8 +37,9 @@ const useWeeklyStateStore = create<WeeklyState>(set => ({
   currentDate: new Date(),
   setCurrentDate: updater => set(state => ({ currentDate: updater(state.currentDate) })),
   totalCountData: {
+    channelName: '',
     completeCount: 0,
-    notCompleteCount: 0,
+    unCompletedCount: 0,
     complimentCount: 0,
     pokeCount: 0,
   },

--- a/src/types/apis/statisticsApi.ts
+++ b/src/types/apis/statisticsApi.ts
@@ -28,7 +28,7 @@ export interface GetWeeklyTotalCountRes extends BaseRes {
     /** 완료 개수 */
     completeCount: number;
     /** 미완료 개수 */
-    notCompleteCount: number;
+    unCompletedCount: number;
     /** 칭찬 개수 */
     complimentCount: number;
     /** 찌르기 개수 */


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약

- 통계 > 주간 > api 연동 및 데이터 처리

## 📌 이슈 넘버

- #433 

## 📝 작업 내용
- API 데이터 연동 및 완료상태에 따른 로직처리
- 랭킹 프로필 기본이미지 처리
- 주간 완료상태에 따른 단계 상수파일 추가
- 아이콘 추가 (BroomDustIcon, BubbleIcon, ShinyIcon, ProfileDefaultIcon)
- SVG 콘솔에러 수정

## 📸 스크린샷(선택)
![image](https://github.com/user-attachments/assets/eba36583-ee6d-4c0d-a87f-d8d6e0550bc0)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
