### PR TITLE
Fix/#623-날짜 format 다시 수정

### DIFF
--- a/src/pages/HouseWorkStepOnePage.tsx
+++ b/src/pages/HouseWorkStepOnePage.tsx
@@ -47,9 +47,13 @@ const HouseWorkStepOnePage = () => {
         try {
           const getHouseResult = await getHouseworkById({ channelId, houseworkId });
           const housework = getHouseResult.result;
+
+          const date = new Date(housework.startDate);
+          const formattedDate = `${date.getFullYear()}년 ${date.getMonth() + 1}월 ${date.getDate()}일`;
+
           setTask(housework.task);
           setCategory(housework.category);
-          setStartDate(housework.startDate);
+          setStartDate(formattedDate);
           setUserId(housework.userId);
           setIsAllday(housework.isAllDay);
           if (!housework.isAllDay) {

--- a/src/utils/convertDate.ts
+++ b/src/utils/convertDate.ts
@@ -1,5 +1,5 @@
 export const formatDateToISO = (date: string) => {
-  return date.replace(/(\d{4})년(\d{1,2})월 (\d{1,2})일/, (_, year, month, day) => {
+  return date.replace(/(\d{4})년 (\d{1,2})월 (\d{1,2})일/, (_, year, month, day) => {
     const formattedMonth = month.padStart(2, '0');
     const formattedDay = day.padStart(2, '0');
     return `${year}-${formattedMonth}-${formattedDay}`;


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약

> 날짜 띄워쓰기를 고치면서 format이 바껴서 오류가 났습니다. 
다시 수정했고, 집안일 수정할때도 2024-12-06을 2024년 12월 6일로 보이게 수정했습니다.

## 📌 이슈 넘버

- #623 

## 📝 작업 내용

## 📸 스크린샷(선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
