### PR TITLE
Feature/#625-프리셋 리스트 없음 및 리스트 분리

### DIFF
--- a/src/components/common/tab/PresetTab/PresetTab.tsx
+++ b/src/components/common/tab/PresetTab/PresetTab.tsx
@@ -1,7 +1,8 @@
 import PresetItem from '@/components/common/preset/PresetItem';
 import PresetTabItem from '@/components/common/tab/PresetTab/PresetTabItem';
 import { Tabs, TabsContent, TabsList } from '@/components/common/ui/tabs';
-import { Category as PresetCategory } from '@/constants/Category';
+import { Category as PresetCategory } from '@/constants/category';
+import { NoHouseWorkIcon } from '@/components/common/icon';
 
 interface PresetItem {
   // 프리셋 아이템 아이디
@@ -56,42 +57,19 @@ const PresetTab: React.FC<PresetTabProps> = ({
           />
         ))}
       </TabsList>
-      <TabsContent
-        key={allPresetData.category}
-        value={allPresetData.category}
-        className={`${isBottomSheet ? 'h-[250px]' : 'h-auto'} overflow-y-auto no-scrollbar`}
-      >
-        {allPresetData.items.map(item => (
-          <div key={item.presetItemId}>
-            <PresetItem
-              category={item.category}
-              housework={item.name}
-              handleSelectClick={() =>
-                handleClick && handleClick(item.presetItemId, item.name, item.category)
-              }
-              isBottomSheet={isBottomSheet}
-              isPresetSettingCustom={isPresetSettingCustom}
-              isShowDeleteBtn={deleteButtonStates[item.presetItemId]} //각 아이템의 boolean값이 들어간다.
-              handleDeleteClick={handleDeleteClick && (() => handleDeleteClick(item.presetItemId))}
-              isSelected={selectedItem === item.presetItemId}
-            />
-          </div>
-        ))}
-      </TabsContent>
-
-      {presetData.map(categoryList => (
+      {allPresetData.items.length ? (
         <TabsContent
-          key={categoryList.presetCategoryId}
-          value={categoryList.category}
+          key={allPresetData.category}
+          value={allPresetData.category}
           className={`${isBottomSheet ? 'h-[250px]' : 'h-auto'} overflow-y-auto no-scrollbar`}
         >
-          {categoryList.presetItemList.map(item => (
+          {allPresetData.items.map(item => (
             <div key={item.presetItemId}>
               <PresetItem
-                category={categoryList.category}
+                category={item.category}
                 housework={item.name}
                 handleSelectClick={() =>
-                  handleClick && handleClick(item.presetItemId, item.name, categoryList.category)
+                  handleClick && handleClick(item.presetItemId, item.name, item.category)
                 }
                 isBottomSheet={isBottomSheet}
                 isPresetSettingCustom={isPresetSettingCustom}
@@ -103,6 +81,49 @@ const PresetTab: React.FC<PresetTabProps> = ({
               />
             </div>
           ))}
+        </TabsContent>
+      ) : (
+        <div className='flex h-[calc(100vh-320px)] items-center justify-center'>
+          <div className='flex flex-col items-center whitespace-pre-line'>
+            <NoHouseWorkIcon />
+            <p className='text-center text-gray3 font-subhead'>{`현재 집안일 목록이 없어요\n 새로운 목록을 만들어보세요`}</p>
+          </div>
+        </div>
+      )}
+
+      {presetData.map(categoryList => (
+        <TabsContent
+          key={categoryList.presetCategoryId}
+          value={categoryList.category}
+          className={`${isBottomSheet ? 'h-[250px]' : 'h-auto'} overflow-y-auto no-scrollbar`}
+        >
+          {categoryList.presetItemList.length ? (
+            categoryList.presetItemList.map(item => (
+              <div key={item.presetItemId}>
+                <PresetItem
+                  category={categoryList.category}
+                  housework={item.name}
+                  handleSelectClick={() =>
+                    handleClick && handleClick(item.presetItemId, item.name, categoryList.category)
+                  }
+                  isBottomSheet={isBottomSheet}
+                  isPresetSettingCustom={isPresetSettingCustom}
+                  isShowDeleteBtn={deleteButtonStates[item.presetItemId]}
+                  handleDeleteClick={
+                    handleDeleteClick && (() => handleDeleteClick(item.presetItemId))
+                  }
+                  isSelected={selectedItem === item.presetItemId}
+                />
+              </div>
+            ))
+          ) : (
+            <div className='flex h-[calc(100vh-320px)] items-center justify-center'>
+              <div className='flex flex-col items-center whitespace-pre-line'>
+                <NoHouseWorkIcon />
+                <p className='text-center text-gray3 font-subhead'>{`현재 집안일 목록이 없어요\n 새로운 목록을 만들어보세요`}</p>
+              </div>
+            </div>
+          )}
         </TabsContent>
       ))}
     </Tabs>

--- a/src/constants/PresetDefault.ts
+++ b/src/constants/PresetDefault.ts
@@ -1,4 +1,4 @@
-import { Category } from '@/constants/Category';
+import { Category } from '@/constants/category';
 
 interface PresetItem {
   // 프리셋 아이템 아이디
@@ -26,7 +26,8 @@ export const PresetDefault: PresetList[] = [
       { presetItemId: 104, name: '진공청소기 돌리기' },
       { presetItemId: 105, name: '바닥 걸레질' },
       { presetItemId: 106, name: '창문 청소' },
-      { presetItemId: 107, name: '카펫 및 러그 청소' },
+      { presetItemId: 107, name: '카펫 청소' },
+      { presetItemId: 108, name: '러그 청소' },
     ],
   },
   {
@@ -47,27 +48,35 @@ export const PresetDefault: PresetList[] = [
     category: Category.KITCHEN,
     presetItemList: [
       { presetItemId: 301, name: '설거지' },
-      { presetItemId: 302, name: '조리대 및 싱크대 닦기' },
-      { presetItemId: 303, name: '쓰레기통 비우기' },
-      { presetItemId: 304, name: '냉장고 정리' },
-      { presetItemId: 305, name: '오븐 및 전자레인지 청소' },
-      { presetItemId: 306, name: '바닥 진공청소기 및 걸레질' },
-      { presetItemId: 307, name: '찬장 및 서랍 정리' },
-      { presetItemId: 308, name: '환풍기 필터 청소' },
+      { presetItemId: 302, name: '조리대 닦기' },
+      { presetItemId: 303, name: '싱크대 닦기' },
+      { presetItemId: 304, name: '쓰레기통 비우기' },
+      { presetItemId: 305, name: '냉장고 정리' },
+      { presetItemId: 306, name: '오븐 청소' },
+      { presetItemId: 307, name: '전자레인지 청소' },
+      { presetItemId: 308, name: '바닥 진공청소기 돌리기' },
+      { presetItemId: 309, name: '바닥 걸레질' },
+      { presetItemId: 310, name: '찬장 정리' },
+      { presetItemId: 311, name: '서랍 정리' },
+      { presetItemId: 312, name: '환풍기 필터 청소' },
     ],
   },
   {
     presetCategoryId: 4,
     category: Category.BATH_ROOM,
     presetItemList: [
-      { presetItemId: 401, name: '세면대 및 거울 닦기' },
-      { presetItemId: 402, name: '변기 청소' },
-      { presetItemId: 403, name: '샤워기 및 욕조 물기 닦기' },
-      { presetItemId: 404, name: '바닥 및 타일 청소' },
-      { presetItemId: 405, name: '샤워 커튼 및 욕조 청소' },
-      { presetItemId: 406, name: '휴지통 비우기' },
-      { presetItemId: 407, name: '배수구 청소' },
-      { presetItemId: 408, name: '환풍기 필터 청소' },
+      { presetItemId: 401, name: '세면대 닦기' },
+      { presetItemId: 402, name: '거울 닦기' },
+      { presetItemId: 403, name: '변기 청소' },
+      { presetItemId: 404, name: '샤워기 물기 닦기' },
+      { presetItemId: 405, name: '욕조 물기 닦기' },
+      { presetItemId: 406, name: '바닥 청소' },
+      { presetItemId: 407, name: '타일 청소' },
+      { presetItemId: 408, name: '샤워 커튼 청소' },
+      { presetItemId: 409, name: '욕조 청소' },
+      { presetItemId: 410, name: '휴지통 비우기' },
+      { presetItemId: 411, name: '배수구 청소' },
+      { presetItemId: 412, name: '환풍기 필터 청소' },
     ],
   },
   {


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약

> 프리셋 관리 페이지 - 프리셋 리스트 없음 및 리스트 분리

## 📌 이슈 넘버

- #625 

## 📝 작업 내용
- 프리셋 리스트가 없으면 없음 컴포넌트 표시
- 및이 포함된 프리셋 리스트를 2개의 리스트로 분리

## 📸 스크린샷(선택)
![image](https://github.com/user-attachments/assets/7361985e-12eb-4b63-8285-800332676477)
![image](https://github.com/user-attachments/assets/3a495672-fdfd-4d9e-85b1-2b225e41cb95)


## 💬리뷰 요구사항(선택)

> 수정 할 사항있으면 말씀해주세요
