### PR TITLE
Feature/#598-메인(홈) 페이지 - 찌르기, 칭찬 액션 수정사항 반영 및 수정불가 로직 추가

### DIFF
--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -133,7 +133,7 @@ const HomePage: React.FC = () => {
   const handleEdit = (houseworkId: number) => {
     const targetHousework = houseworks?.find(housework => housework.houseworkId === houseworkId);
     if (targetHousework?.status === HOUSEWORK_STATUS.COMPLETE) {
-      toast({ title: '완료한 집안일은 수정할 수 없어요!' });
+      toast({ title: '완료한 집안일은 수정할 수 없어요' });
     } else {
       navigate(`/add-housework/edit/${channelId}/${houseworkId}/step1`);
     }

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -132,7 +132,12 @@ const HomePage: React.FC = () => {
   };
 
   const handleEdit = (houseworkId: number) => {
-    navigate(`/add-housework/edit/${channelId}/${houseworkId}/step1`);
+    const targetHousework = houseworks?.find(housework => housework.houseworkId === houseworkId);
+    if (targetHousework?.status === HOUSEWORK_STATUS.COMPLETE) {
+      toast({ title: '완료한 집안일은 수정할 수 없어요!' });
+    } else {
+      navigate(`/add-housework/edit/${channelId}/${houseworkId}/step1`);
+    }
   };
 
   const handleDelete = async (houseworkId: number) => {

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -20,7 +20,6 @@ import { HOUSEWORK_STATUS } from '@/constants/homePage';
 import NoListIcon from '@/components/common/icon/NoListIcon';
 import { postCompliment } from '@/services/noticeManage/postCompliment';
 import { postPoke } from '@/services/noticeManage/postPoke';
-import getFormattedDate from './../utils/getFormattedDate';
 
 const HomePage: React.FC = () => {
   const {
@@ -117,14 +116,14 @@ const HomePage: React.FC = () => {
         await postCompliment({
           channelId: newChannelId,
           targetUserId: targetHousework.userId,
-          reactDate: getFormattedDate(new Date()),
+          reactDate: targetHousework.startDate,
         });
         toast({ title: `${targetHousework.assignee}님을 칭찬했어요` });
       } else {
         await postPoke({
           channelId: newChannelId,
           targetUserId: targetHousework?.userId!,
-          reactDate: getFormattedDate(new Date()),
+          reactDate: targetHousework?.startDate!,
         });
         toast({ title: `${targetHousework?.assignee}님을 찔렀어요` });
       }

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -20,6 +20,7 @@ import { HOUSEWORK_STATUS } from '@/constants/homePage';
 import NoListIcon from '@/components/common/icon/NoListIcon';
 import { postCompliment } from '@/services/noticeManage/postCompliment';
 import { postPoke } from '@/services/noticeManage/postPoke';
+import getFormattedDate from './../utils/getFormattedDate';
 
 const HomePage: React.FC = () => {
   const {
@@ -113,10 +114,18 @@ const HomePage: React.FC = () => {
       refetch();
     } else {
       if (targetHousework?.status === HOUSEWORK_STATUS.COMPLETE) {
-        await postCompliment({ channelId: newChannelId, targetUserId: targetHousework.userId });
+        await postCompliment({
+          channelId: newChannelId,
+          targetUserId: targetHousework.userId,
+          reactDate: getFormattedDate(new Date()),
+        });
         toast({ title: `${targetHousework.assignee}님을 칭찬했어요` });
       } else {
-        await postPoke({ channelId: newChannelId, targetUserId: targetHousework?.userId! });
+        await postPoke({
+          channelId: newChannelId,
+          targetUserId: targetHousework?.userId!,
+          reactDate: getFormattedDate(new Date()),
+        });
         toast({ title: `${targetHousework?.assignee}님을 찔렀어요` });
       }
     }

--- a/src/services/noticeManage/postCompliment.ts
+++ b/src/services/noticeManage/postCompliment.ts
@@ -1,11 +1,11 @@
 import { axiosInstance } from '@/services/axiosInstance';
 import { ComplimentReq, ComplimentRes } from '@/types/apis/noticeManage';
 
-export const postCompliment = async ({ channelId, targetUserId }: ComplimentReq) => {
+export const postCompliment = async ({ channelId, targetUserId, reactDate }: ComplimentReq) => {
   try {
     const response = await axiosInstance.post<ComplimentRes>(
       `/api/v1/channels/${channelId}/reactions/compliment`,
-      { targetUserId }
+      { targetUserId, reactDate }
     );
     return response.data;
   } catch (error) {

--- a/src/services/noticeManage/postPoke.ts
+++ b/src/services/noticeManage/postPoke.ts
@@ -1,11 +1,11 @@
 import { axiosInstance } from '@/services/axiosInstance';
 import { PokeReq, PokeRes } from '@/types/apis/noticeManage';
 
-export const postPoke = async ({ channelId, targetUserId }: PokeReq) => {
+export const postPoke = async ({ channelId, targetUserId, reactDate }: PokeReq) => {
   try {
     const response = await axiosInstance.post<PokeRes>(
       `/api/v1/channels/${channelId}/reactions/poke`,
-      { targetUserId }
+      { targetUserId, reactDate }
     );
     return response.data;
   } catch (error) {

--- a/src/types/apis/noticeManage.ts
+++ b/src/types/apis/noticeManage.ts
@@ -3,6 +3,7 @@ import { Common } from '@/types/apis/commonApi';
 
 export interface ComplimentReq extends Pick<Common, 'channelId'> {
   targetUserId: number;
+  reactDate: string;
 }
 
 export interface ComplimentRes extends BaseRes {
@@ -11,6 +12,7 @@ export interface ComplimentRes extends BaseRes {
 
 export interface PokeReq extends Pick<Common, 'channelId'> {
   targetUserId: number;
+  reactDate: string;
 }
 
 export interface PokeRes extends BaseRes {


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약

> 메인(홈) 페이지 - 찌르기, 칭찬 액션 수정사항 반영
> 메인(홈) 페이지 - 완료한 집안일은 수정할 수 없게 수정

## 📌 이슈 넘버

- #598 

## 📝 작업 내용
- api 타입 정의 수정(reactDate 추가)
- api 함수 수정
- 메인(홈) 페이지에 반영

## 📸 스크린샷(선택)
![image](https://github.com/user-attachments/assets/4d5104a3-add7-40cd-97ec-d57cc49a8303)
![image](https://github.com/user-attachments/assets/20d5d92a-a3f4-4dd0-9976-6390845cae7e)



## 💬리뷰 요구사항(선택)

> 수정 할 사항있으면 말씀주세요!
