### PR TITLE
Feature/#630-메인(홈) 페이지 디버그

### DIFF
--- a/src/components/home/WeeklyDate/WeeklyDate.tsx
+++ b/src/components/home/WeeklyDate/WeeklyDate.tsx
@@ -21,6 +21,7 @@ const WeeklyDate = () => {
     setWeekText(getWeekText(today));
     fetchCurrWeek(getFormattedDate(today));
     setActiveWeek(today);
+    setActiveDate(getFormattedDate(today));
   }, [channelId]);
 
   useEffect(() => {

--- a/src/components/home/WeeklyDate/WeeklyDate.tsx
+++ b/src/components/home/WeeklyDate/WeeklyDate.tsx
@@ -9,16 +9,11 @@ import { getWeeklyIncomplete } from '@/services/housework/getWeeklyIncomplete';
 import { useParams } from 'react-router-dom';
 import getFormattedDate from '@/utils/getFormattedDate';
 
-interface WeeklyDates extends IncompleteScoreResponse {
-  day: string;
-}
-
 const WeeklyDate = () => {
   const [activeWeek, setActiveWeek] = useState(new Date());
-  const [currWeek, setCurrWeek] = useState<WeeklyDates[]>([]);
   const [api, setApi] = useState<CarouselApi>();
   const [current, setCurrent] = useState(0);
-  const { setWeekText, activeDate, setActiveDate } = useHomePageStore();
+  const { setWeekText, activeDate, setActiveDate, currWeek, setCurrWeek } = useHomePageStore();
   const { channelId } = useParams();
 
   useEffect(() => {

--- a/src/store/useHomePageStore.ts
+++ b/src/store/useHomePageStore.ts
@@ -2,6 +2,11 @@ import { create } from 'zustand';
 import { Group } from '@/types/apis/groupApi';
 import getFormattedDate from '@/utils/getFormattedDate';
 import { UserBase } from '@/types/apis/userApi';
+import { IncompleteScoreResponse } from '@/types/apis/houseworkApi';
+
+interface WeeklyDates extends IncompleteScoreResponse {
+  day: string;
+}
 
 interface HomePageState {
   currentGroup: Group;
@@ -27,6 +32,9 @@ interface HomePageState {
 
   myInfo: UserBase | null;
   setMyInfo: (newMyInfo: UserBase) => void;
+
+  currWeek: WeeklyDates[];
+  setCurrWeek: (newWeek: WeeklyDates[]) => void;
 }
 
 const useHomePageStore = create<HomePageState>(set => ({
@@ -53,6 +61,9 @@ const useHomePageStore = create<HomePageState>(set => ({
 
   myInfo: null,
   setMyInfo: newMyInfo => set({ myInfo: newMyInfo }),
+
+  currWeek: [],
+  setCurrWeek: newWeek => set({ currWeek: newWeek }),
 }));
 
 export default useHomePageStore;


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약

> 메인(홈) 페이지 - 집안일 완료 체크 실시간 반영 및 집안일 추가시 날짜 초기화

## 📌 이슈 넘버

- #630 

## 📝 작업 내용
- 집안일 완료 체크시 주간 미완료 개수에 반영
- 집안일 추가 페이지에서 홈페이지로 전환시 현재 날짜로 초기화
- 그룹 변경시 활성화된 날짜 초기화

## 📸 스크린샷(선택)

## 💬리뷰 요구사항(선택)

> 수정 할 사항있으면 말씀해주세요
