### PR TITLE
Feature/#652-프리셋 아이템 삭제 시 카테고리아이디 함께 전달

### DIFF
--- a/src/components/common/tab/PresetTab/PresetTab.tsx
+++ b/src/components/common/tab/PresetTab/PresetTab.tsx
@@ -23,7 +23,7 @@ interface PresetTabProps {
   presetData: PresetList[];
   isPresetSettingCustom?: boolean;
   deleteButtonStates?: Record<number, boolean>;
-  handleDeleteClick?: (itemId: number) => void;
+  handleDeleteClick?: (presetCategoryId: number, itemId: number) => void;
   isBottomSheet?: boolean;
   handleClick?: (id: number, description: string, category: string) => void;
   selectedItem?: number | null;
@@ -41,7 +41,11 @@ const PresetTab: React.FC<PresetTabProps> = ({
   const allPresetData = {
     category: PresetCategory.ALL,
     items: presetData.flatMap(categoryList =>
-      categoryList.presetItemList.map(item => ({ ...item, category: categoryList.category }))
+      categoryList.presetItemList.map(item => ({
+        ...item,
+        category: categoryList.category,
+        presetCategoryId: categoryList.presetCategoryId,
+      }))
     ),
   };
 
@@ -75,7 +79,8 @@ const PresetTab: React.FC<PresetTabProps> = ({
                 isPresetSettingCustom={isPresetSettingCustom}
                 isShowDeleteBtn={deleteButtonStates[item.presetItemId]} //각 아이템의 boolean값이 들어간다.
                 handleDeleteClick={
-                  handleDeleteClick && (() => handleDeleteClick(item.presetItemId))
+                  handleDeleteClick &&
+                  (() => handleDeleteClick(item.presetCategoryId, item.presetItemId))
                 }
                 isSelected={selectedItem === item.presetItemId}
               />
@@ -110,7 +115,8 @@ const PresetTab: React.FC<PresetTabProps> = ({
                   isPresetSettingCustom={isPresetSettingCustom}
                   isShowDeleteBtn={deleteButtonStates[item.presetItemId]}
                   handleDeleteClick={
-                    handleDeleteClick && (() => handleDeleteClick(item.presetItemId))
+                    handleDeleteClick &&
+                    (() => handleDeleteClick(categoryList.presetCategoryId, item.presetItemId))
                   }
                   isSelected={selectedItem === item.presetItemId}
                 />

--- a/src/hooks/usePresetSetting.ts
+++ b/src/hooks/usePresetSetting.ts
@@ -74,11 +74,11 @@ const usePresetSetting = () => {
     setDeleteButtonStates(isDeselecting ? null : presetItemId);
   };
 
-  const handleDeleteClick = async (presetItemId: number) => {
+  const handleDeleteClick = async (presetCategoryId: number, presetItemId: number) => {
     setDeleteButtonStates(null);
 
     try {
-      await deletePresetItem({ channelId, presetItemId });
+      await deletePresetItem({ channelId, presetCategoryId, presetItemId });
       // 업데이트된 아이템 리스트 조회
       await getPresetData();
     } catch (error) {

--- a/src/services/preset/deletePresetItem.ts
+++ b/src/services/preset/deletePresetItem.ts
@@ -4,7 +4,7 @@ import { DeletePresetItemReq, DeletePresetItemRes } from '@/types/apis/presetApi
 export const deletePresetItem = async (data: DeletePresetItemReq) => {
   try {
     const response = await axiosInstance.delete<DeletePresetItemRes>(
-      `/api/v1/channels/${data.channelId}/presets/items/${data.presetItemId}`
+      `/api/v1/channels/${data.channelId}/presets/categories/${data.presetCategoryId}/items/${data.presetItemId}`
     );
     return response.data;
   } catch (error) {

--- a/src/types/apis/presetApi.ts
+++ b/src/types/apis/presetApi.ts
@@ -107,6 +107,8 @@ export interface CreatePresetItemRes extends BaseRes {
 
 /** 프리셋 아이템 삭제 */
 export interface DeletePresetItemReq extends Pick<Common, 'channelId'> {
+  /** 프리셋 카테고리 아이디 */
+  presetCategoryId: number;
   /** 프리셋 아이템 아이디 */
   presetItemId: number;
 }


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약

- 프리셋 아이템 삭제 시 카테고리아이디 함께 전달

## 📌 이슈 넘버

- #652 

## 📝 작업 내용

- 프리셋 아이템 삭제 시 카테고리아이디 함께 전달

## 📸 스크린샷(선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
