### PR TITLE
Feature/#655-프리셋 탭 순서 변경

### DIFF
--- a/src/constants/tabName.ts
+++ b/src/constants/tabName.ts
@@ -1,4 +1,4 @@
 export const PresetTabName = {
-  PRESET_DATA: '프리셋',
   USER_DATA: '사용자정의',
+  PRESET_DATA: '프리셋',
 };

--- a/src/store/usePresetSettingStore.ts
+++ b/src/store/usePresetSettingStore.ts
@@ -48,7 +48,7 @@ interface PresetState {
 const usePresetSettingStore = create<PresetState>(set => ({
   categoryList: [],
   setCategoryList: categoryList => set({ categoryList }),
-  activeTab: PresetTabName.PRESET_DATA,
+  activeTab: PresetTabName.USER_DATA,
   // TODO 공통 Tab컴포넌트 Props 타입을 맞추기위함으로 불필요하다면 Tab컴포넌트 Props 변경필요
   setActiveTab: activeTab =>
     set(state => ({


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약

- 프리셋 탭 순서 변경

## 📌 이슈 넘버

- #655 

## 📝 작업 내용

- 프리셋 탭 순서 변경

## 📸 스크린샷(선택)
![image](https://github.com/user-attachments/assets/c841544a-6c5f-4767-ae83-571ac420597f)


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
