### PR TITLE
Feature/#666-집안일 수정 사용성 개선

### DIFF
--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -159,7 +159,7 @@ const HomePage: React.FC = () => {
     if (targetHousework?.status === HOUSEWORK_STATUS.COMPLETE) {
       toast({ title: '완료한 집안일은 수정할 수 없어요' });
     } else {
-      navigate(`/add-housework/edit/${channelId}/${houseworkId}/step1`);
+      navigate(`/add-housework/edit/${channelId}/${houseworkId}/step1`, { state: targetHousework });
     }
   };
 

--- a/src/pages/HouseWorkStepOnePage.tsx
+++ b/src/pages/HouseWorkStepOnePage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import Button from '@/components/common/button/Button/Button';
 import OpenSheetBtn from '@/components/common/button/OpenSheetBtn/OpenSheetBtn';
 import OpenSheetBtnWithLabel from '@/components/common/button/OpenSheetBtn/OpenSheetBtnWithLabel';
@@ -9,7 +9,6 @@ import DueDateSheet from '@/components/housework/DueDateSheet/DueDateSheet';
 import TimeControl from '@/components/housework/TimeControl/TimeControl';
 import useAddHouseWorkStore from '@/store/useAddHouseWorkStore';
 import { useParams } from 'react-router-dom';
-import { getHouseworkById } from '@/services/housework/getHouseworkById';
 import { DateIcon, EtcIcon } from '@/components/common/icon';
 import convertTimeToObject from '@/utils/convertTimeToObject';
 import useDeviceHeight from '@/hooks/useDevice';
@@ -43,31 +42,26 @@ const HouseWorkStepOnePage = () => {
   const channelId = Number(strChannelId);
   const houseworkId = Number(strHouseworkId);
 
+  const location = useLocation();
+  const targetHousework = location.state;
+
+  console.log('가져온거', targetHousework);
+
   useEffect(() => {
-    if (channelId && houseworkId) {
-      const fetchHouseworkById = async () => {
-        try {
-          const getHouseResult = await getHouseworkById({ channelId, houseworkId });
-          const housework = getHouseResult.result;
+    if (targetHousework) {
+      setTask(targetHousework.task);
 
-          const date = new Date(housework.startDate);
-          const formattedDate = `${date.getFullYear()}년 ${date.getMonth() + 1}월 ${date.getDate()}일`;
+      const date = new Date(targetHousework.startDate);
+      const formattedDate = `${date.getFullYear()}년 ${date.getMonth() + 1}월 ${date.getDate()}일`;
 
-          setTask(housework.task);
-          setCategory(housework.category);
-          setStartDate(formattedDate);
-          setUserId(housework.userId);
-          setIsAllday(housework.isAllDay);
-          if (!housework.isAllDay) {
-            const result = convertTimeToObject(housework.startTime!);
-            setStartTime(result);
-          }
-        } catch (error) {
-          console.error('집안일 상세 정보 조회 실패:', error);
-        }
-      };
-
-      fetchHouseworkById();
+      setStartDate(formattedDate);
+      setCategory(targetHousework.category);
+      setUserId(targetHousework.userId);
+      setIsAllday(targetHousework.isAllDay);
+      if (!targetHousework.isAllDay && targetHousework.startTime) {
+        const result = convertTimeToObject(targetHousework.startTime);
+        setStartTime(result);
+      }
     }
   }, []);
 

--- a/src/pages/HouseWorkStepTwoPage.tsx
+++ b/src/pages/HouseWorkStepTwoPage.tsx
@@ -26,6 +26,7 @@ const HouseWorkStepTwoPage = () => {
   const [selectedValue, setSelectedValue] = useState(userId || null);
   const [members, setMembers] = useState<User[]>([]);
   const customHeightClass = useDeviceHeight();
+  const [isMemberLoading, setIsMemberLoading] = useState(true);
 
   const channelId = Number(strChannelId);
 
@@ -36,11 +37,17 @@ const HouseWorkStepTwoPage = () => {
         setMembers(response.result.userList);
       } catch (error) {
         console.error('멤버 조회 실패:', error);
+      } finally {
+        setIsMemberLoading(false);
       }
     };
 
     fetchGroupMembers();
   }, []);
+
+  if (isMemberLoading) {
+    return <></>;
+  }
 
   console.log('전역:', task, category, startDate, startTime, userId);
 


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약

> 값을 useEffect로 조회하는 게 아니라 navigate로 넘어가게 수정했습니다.
근데 스텝2도 현재 방 안에 멤버 리스트가 넘어오면 좋겠는데.. 그러면 데이터 구조를 싹 바꿔야해서 우선은 로딩처리로 해놨습니다.

## 📌 이슈 넘버

- #666 

## 📝 작업 내용

## 📸 스크린샷(선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
