### PR TITLE
Fix/#710-메인 페이지 주간 날짜 디버그

### DIFF
--- a/src/components/statistics/weekly/WeeklyStatDate/WeeklyStatDate.tsx
+++ b/src/components/statistics/weekly/WeeklyStatDate/WeeklyStatDate.tsx
@@ -1,5 +1,6 @@
 import { ArrowLeftIcon, ArrowRightIcon } from '@/components/common/icon';
 import React from 'react';
+import getWeekText from '@/utils/getWeekText';
 
 export interface WeeklyStatDateProps {
   /** 현재 날짜 */
@@ -15,29 +16,6 @@ const WeeklyStatDate: React.FC<WeeklyStatDateProps> = ({
   handlePrevWeek,
   handleNextWeek,
 }) => {
-  // todo
-  // utils에 분리
-  const getWeekText = (date: Date) => {
-    const year = date.getFullYear();
-    const month = date.getMonth(); // 0부터 시작하므로 11월은 10
-    const firstDayOfMonth = new Date(year, month, 1);
-    const firstDayOfWeek = firstDayOfMonth.getDay();
-
-    // 한 주의 시작이 일요일부터 시작되도록 함
-    const adjustedDay = date.getDate() + firstDayOfWeek; // 날짜 + 첫 주의 시작 위치 보정
-    const weekNumber = Math.ceil(adjustedDay / 7);
-
-    const weekLabels: { [key: number]: string } = {
-      1: '첫째 주',
-      2: '둘째 주',
-      3: '셋째 주',
-      4: '넷째 주',
-      5: '다섯째 주',
-    };
-
-    return `${year}년 ${new Intl.DateTimeFormat('ko-KR', { month: 'long' }).format(date)} ${weekLabels[weekNumber]}`;
-  };
-
   // 다음 주로 이동 금지 조건 (오늘 날짜 기준으로 바로 비활성화)
   const isNextWeekDisabled = () => {
     const today = new Date();

--- a/src/utils/getWeekText.ts
+++ b/src/utils/getWeekText.ts
@@ -4,24 +4,17 @@ export default function getWeekText(date: Date) {
   const firstDayOfMonth = new Date(year, month, 1);
   const firstDayOfWeek = firstDayOfMonth.getDay();
 
-  // 한 주의 시작이 일요일로 설정
-  // 주차 계산을 위해 요일을 일요일 기준으로 조정
-  const adjustedDay = date.getDate() + (firstDayOfWeek === 0 ? 0 : 7 - firstDayOfWeek);
+  // 한 주의 시작이 일요일부터 시작되도록 함
+  const adjustedDay = date.getDate() + firstDayOfWeek; // 날짜 + 첫 주의 시작 위치 보정
   const weekNumber = Math.ceil(adjustedDay / 7);
 
-  // 주차 대신 "첫째 주", "둘째 주" 형식으로 반환
-  const weekText =
-    weekNumber === 1
-      ? '첫째 주'
-      : weekNumber === 2
-        ? '둘째 주'
-        : weekNumber === 3
-          ? '셋째 주'
-          : weekNumber === 4
-            ? '넷째 주'
-            : weekNumber === 5
-              ? '다섯째 주'
-              : '여섯째 주 이상';
+  const weekLabels: { [key: number]: string } = {
+    1: '첫째 주',
+    2: '둘째 주',
+    3: '셋째 주',
+    4: '넷째 주',
+    5: '다섯째 주',
+  };
 
-  return `${year}년 ${new Intl.DateTimeFormat('ko-KR', { month: 'long' }).format(date)} ${weekText}`;
+  return `${year}년 ${new Intl.DateTimeFormat('ko-KR', { month: 'long' }).format(date)} ${weekLabels[weekNumber]}`;
 }


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약

> 메인 페이지 - 주간 날짜 둘째주 오류 디버그

## 📌 이슈 넘버

- #710 

## 📝 작업 내용
- 주간 통계에서 사용하는 주간 날짜 함수 유틸로 분리
- 메인 페이지 주간 날짜 디버그

## 📸 스크린샷(선택)
![image](https://github.com/user-attachments/assets/04cf6634-5145-4e6c-b587-834381f6a560)


## 💬리뷰 요구사항(선택)

> 수정 할 사항 있으면 말씀해주세요
