### PR TITLE
Feature/#704-프리셋 설정 페이지 수정

### DIFF
--- a/src/components/common/tab/PresetTab/PresetTab.tsx
+++ b/src/components/common/tab/PresetTab/PresetTab.tsx
@@ -108,7 +108,7 @@ const PresetTab: React.FC<PresetTabProps> = ({
         <TabsContent
           key={categoryList.presetCategoryId}
           value={categoryList.category}
-          className={`${isBottomSheet ? 'h-[250px]' : 'h-[calc(100vh-320px)]'} overflow-y-auto no-scrollbar`}
+          className={`${isBottomSheet ? 'h-[250px]' : 'h-auto'} overflow-y-auto no-scrollbar`}
         >
           {categoryList.presetItemList.length ? (
             categoryList.presetItemList.map(item => (

--- a/src/components/common/tab/PresetTab/PresetTab.tsx
+++ b/src/components/common/tab/PresetTab/PresetTab.tsx
@@ -21,6 +21,8 @@ interface PresetList {
 
 interface PresetTabProps {
   presetData: PresetList[];
+  cateActiveTab?: string;
+  setCateActiveTab?: (cateActiveTab: string) => void;
   isPresetSettingCustom?: boolean;
   deleteButtonStates?: Record<number, boolean>;
   handleDeleteClick?: (presetCategoryId: number, itemId: number) => void;
@@ -31,6 +33,8 @@ interface PresetTabProps {
 
 const PresetTab: React.FC<PresetTabProps> = ({
   presetData,
+  cateActiveTab,
+  setCateActiveTab,
   isPresetSettingCustom = false,
   deleteButtonStates = {},
   handleDeleteClick,
@@ -50,7 +54,7 @@ const PresetTab: React.FC<PresetTabProps> = ({
   };
 
   return (
-    <Tabs defaultValue={PresetCategory.ALL}>
+    <Tabs defaultValue={PresetCategory.ALL} value={cateActiveTab} onValueChange={setCateActiveTab}>
       <TabsList className='flex h-full w-full justify-start gap-4 overflow-x-auto bg-white p-0 px-5 no-scrollbar'>
         <PresetTabItem name={allPresetData.category} value={allPresetData.category} />
         {presetData.map(categoryList => (

--- a/src/components/setting/presetSetting/PresetAddInput.tsx
+++ b/src/components/setting/presetSetting/PresetAddInput.tsx
@@ -35,6 +35,13 @@ const PresetAddInput: React.FC<PresetAddInputProps> = ({ categoryList, handleAdd
     setActiveInputCateId(cateId);
   };
 
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value;
+    if (value.length <= INPUT_VALIDATION.preset.maxLength) {
+      setInputVal(value);
+    }
+  };
+
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
     if (e.key === 'Enter' && inputVal.trim()) {
       handleAddInput(inputVal, activeInputCateId);
@@ -42,10 +49,10 @@ const PresetAddInput: React.FC<PresetAddInputProps> = ({ categoryList, handleAdd
     }
   };
 
-  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const value = e.target.value;
-    if (value.length <= INPUT_VALIDATION.preset.maxLength) {
-      setInputVal(value);
+  const handleIconClick = () => {
+    if (inputVal.trim()) {
+      handleAddInput(inputVal, activeInputCateId);
+      setInputVal('');
     }
   };
 
@@ -58,15 +65,17 @@ const PresetAddInput: React.FC<PresetAddInputProps> = ({ categoryList, handleAdd
       />
       <div className='relative text-gray1'>
         <input
-          className='border-gray3_30 h-12 w-full rounded-lg border-[1px] px-2 py-4 pr-10 transition-colors font-label focus:border-main focus:outline-none'
+          className='h-12 w-full rounded-lg border-[1px] border-gray3_30 px-2 py-4 pr-10 transition-colors font-label focus:border-main focus:outline-none'
           placeholder='집안일을 입력해주세요 (최대 13글자)'
           value={inputVal}
           onChange={handleInputChange}
           onKeyDown={handleKeyDown}
         />
-        <EnterIcon
-          className={`${inputVal ? 'text-sub' : 'text-gray4'} absolute right-2 top-1/2 -translate-y-1/2`}
-        />
+        <div onClick={handleIconClick}>
+          <EnterIcon
+            className={`${inputVal ? 'text-sub' : 'text-gray4'} absolute right-2 top-1/2 -translate-y-1/2`}
+          />
+        </div>
       </div>
     </div>
   );

--- a/src/constants/common.ts
+++ b/src/constants/common.ts
@@ -1,1 +1,1 @@
-export const PAGE_SIZE = 10;
+export const PAGE_SIZE = 100;

--- a/src/hooks/usePresetSetting.ts
+++ b/src/hooks/usePresetSetting.ts
@@ -7,7 +7,7 @@ import {
 } from '@/services/preset';
 import usePresetSettingStore from '@/store/usePresetSettingStore';
 import { useNavigate, useParams } from 'react-router-dom';
-import { PresetDefault, PresetTabName } from '@/constants';
+import { Category, PresetDefault, PresetTabName } from '@/constants';
 
 const usePresetSetting = () => {
   const navigate = useNavigate();
@@ -18,6 +18,7 @@ const usePresetSetting = () => {
     setPresetData,
     selectedItem,
     setSelectedItem,
+    setCateActiveTab,
   } = usePresetSettingStore();
   const { channelId: strChannelId } = useParams();
   const channelId = Number(strChannelId);
@@ -38,6 +39,7 @@ const usePresetSetting = () => {
 
   useEffect(() => {
     getPresetData();
+    setCateActiveTab(Category.ALL);
   }, [activeTab]);
 
   const getPresetData = async () => {

--- a/src/hooks/usePresetSetting.ts
+++ b/src/hooks/usePresetSetting.ts
@@ -15,6 +15,7 @@ const usePresetSetting = () => {
     setCategoryList,
     setDeleteButtonStates,
     activeTab,
+    setActiveTab,
     setPresetData,
     selectedItem,
     setSelectedItem,
@@ -93,11 +94,27 @@ const usePresetSetting = () => {
     navigate(-1);
   };
 
+  const handleTabChange = (value: string) => {
+    setActiveTab(value);
+    window.scrollTo({
+      top: 0,
+    });
+  };
+
+  const handleCateTabChange = (value: string) => {
+    setCateActiveTab(value);
+    window.scrollTo({
+      top: 0,
+    });
+  };
+
   return {
     handleAddInput,
     handleSelectClick,
     handleDeleteClick,
     handleBack,
+    handleTabChange,
+    handleCateTabChange,
   };
 };
 

--- a/src/hooks/usePresetSetting.ts
+++ b/src/hooks/usePresetSetting.ts
@@ -65,6 +65,7 @@ const usePresetSetting = () => {
       });
       // 업데이트된 아이템 리스트 조회
       await getPresetData();
+      setCateActiveTab(Category.ALL);
     } catch (error) {
       console.error('프리셋 아이템 추가 오류: ', error);
     }

--- a/src/pages/PresetSettingPage.tsx
+++ b/src/pages/PresetSettingPage.tsx
@@ -8,8 +8,15 @@ import usePresetSetting from '@/hooks/usePresetSetting';
 import usePresetSettingStore from '@/store/usePresetSettingStore';
 
 const PresetSettingPage = () => {
-  const { categoryList, activeTab, setActiveTab, deleteButtonStates, presetData } =
-    usePresetSettingStore();
+  const {
+    categoryList,
+    activeTab,
+    setActiveTab,
+    cateActiveTab,
+    setCateActiveTab,
+    deleteButtonStates,
+    presetData,
+  } = usePresetSettingStore();
   const { handleAddInput, handleSelectClick, handleDeleteClick, handleBack } = usePresetSetting();
 
   return (
@@ -27,6 +34,8 @@ const PresetSettingPage = () => {
           <div className='mt-5 flex-1'>
             <PresetTab
               presetData={presetData}
+              cateActiveTab={cateActiveTab}
+              setCateActiveTab={setCateActiveTab}
               isPresetSettingCustom={true}
               deleteButtonStates={deleteButtonStates}
               handleDeleteClick={handleDeleteClick}

--- a/src/pages/PresetSettingPage.tsx
+++ b/src/pages/PresetSettingPage.tsx
@@ -11,13 +11,20 @@ const PresetSettingPage = () => {
   const {
     categoryList,
     activeTab,
-    setActiveTab,
+    // setActiveTab,
     cateActiveTab,
-    setCateActiveTab,
+    // setCateActiveTab,
     deleteButtonStates,
     presetData,
   } = usePresetSettingStore();
-  const { handleAddInput, handleSelectClick, handleDeleteClick, handleBack } = usePresetSetting();
+  const {
+    handleAddInput,
+    handleSelectClick,
+    handleDeleteClick,
+    handleBack,
+    handleTabChange,
+    handleCateTabChange,
+  } = usePresetSetting();
 
   return (
     <div className={`flex h-screen flex-col`}>
@@ -25,7 +32,7 @@ const PresetSettingPage = () => {
         <Header title='프리셋 관리' isNeededDoneBtn={false} handleBack={handleBack} />
         <Tab
           activeTab={activeTab}
-          handleSetActiveTab={setActiveTab}
+          handleSetActiveTab={handleTabChange}
           chargers={convertTabNameToChargers(PresetTabName)}
         />
       </div>
@@ -35,7 +42,7 @@ const PresetSettingPage = () => {
             <PresetTab
               presetData={presetData}
               cateActiveTab={cateActiveTab}
-              setCateActiveTab={setCateActiveTab}
+              setCateActiveTab={handleCateTabChange}
               isPresetSettingCustom={true}
               deleteButtonStates={deleteButtonStates}
               handleDeleteClick={handleDeleteClick}

--- a/src/store/usePresetSettingStore.ts
+++ b/src/store/usePresetSettingStore.ts
@@ -25,6 +25,9 @@ interface PresetState {
   // 활성화 탭 (사용자정의 | 프리셋)
   activeTab: string;
   setActiveTab: (activeTab: string | ((prevState: string) => string)) => void;
+  // 카테고리 활성화 탭
+  cateActiveTab: string;
+  setCateActiveTab: (cateActiveTab: string) => void;
   // input 값
   inputVal: string;
   setInputVal: (inputVal: string) => void;
@@ -54,6 +57,8 @@ const usePresetSettingStore = create<PresetState>(set => ({
     set(state => ({
       activeTab: typeof activeTab === 'function' ? activeTab(state.activeTab) : activeTab,
     })),
+  cateActiveTab: Category.ALL,
+  setCateActiveTab: cateActiveTab => set({ cateActiveTab }),
   inputVal: '',
   setInputVal: inputVal => set({ inputVal }),
   activeInputCate: '',


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약

- 프리셋 설정 페이지 수정

## 📌 이슈 넘버

- #704 

## 📝 작업 내용

- 아이템 추가 및 탭 이동 시, 전체 카테고리로 이동 처리
- 고정된 높이로 인해 리스트 미노출되는 에러 수정
- 탭 이동 시, scroll to top 추가
- 아이템 입력창에서 아이콘 클릭시 추가되도록 처리

## 📸 스크린샷(선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
