### PR TITLE
Feature/#718-집안일 프리셋시트 > 리스트 없을때 이미지 위치조정

### DIFF
--- a/src/components/common/tab/PresetTab/PresetTab.tsx
+++ b/src/components/common/tab/PresetTab/PresetTab.tsx
@@ -94,7 +94,7 @@ const PresetTab: React.FC<PresetTabProps> = ({
           </>
         ) : (
           <div
-            className={`${isBottomSheet ? 'h-[calc(100vh-510px)]' : 'h-[calc(100vh-320px)]'} flex items-center justify-center`}
+            className={`${isBottomSheet ? 'h-[calc(100vh-400px)]' : 'h-[calc(100vh-320px)]'} flex items-center justify-center`}
           >
             <div className='flex flex-col items-center whitespace-pre-line'>
               <NoHouseWorkIcon />
@@ -132,7 +132,7 @@ const PresetTab: React.FC<PresetTabProps> = ({
             ))
           ) : (
             <div
-              className={`${isBottomSheet ? 'h-[calc(100vh-510px)]' : 'h-[calc(100vh-320px)]'} flex items-center justify-center`}
+              className={`${isBottomSheet ? 'h-[calc(100vh-400px)]' : 'h-[calc(100vh-320px)]'} flex items-center justify-center`}
             >
               <div className='flex flex-col items-center whitespace-pre-line'>
                 <NoHouseWorkIcon />


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약

- 집안일 프리셋시트 > 리스트 없을때 이미지 위치조정

## 📌 이슈 넘버

- #718 

## 📝 작업 내용

- 리스트 없을때 이미지 위치조정

## 📸 스크린샷(선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
